### PR TITLE
Support Java 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
-dist: xenial
-
-sudo: false
-
 language: java
 
 jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
   - openjdk11
 
 cache:
   directories:
-    - $HOME/.m2/repository
+    - $HOME/.m2
 
 before_script:
   - java -version
-
-script:
-  - mvn test
-

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,18 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.build.source>1.8</project.build.source>
+		<project.build.target>1.8</project.build.target>
 	</properties>
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 				<configuration>
-					<encoding>UTF-8</encoding>
-					<release>11</release>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<source>${project.build.source}</source>
+					<target>${project.build.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -105,6 +108,12 @@
 			<groupId>org.codelibs.xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
 			<version>2.12.0-sp1</version>
+		</dependency>
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
There are still a LOT of Java 1.8 systems out there. This change enables the code to built on Java 1.8. This makes it usable on JDK 1.8, 9, 10, 11, etc.

If you are willing to accept this, would you also be willing to build a release using JDK 8 and publish it to Maven Central please?

Thanks Adam.