### PR TITLE
Migrate to Java 17, update dependencies, and enhance Javadoc comments

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 .project
 /target
 /.settings
+/.serena

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<packaging>jar</packaging>
 	<name>Neko HTML</name>
 	<description>An HTML parser and tag balancer.</description>
-	<version>2.1.4-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<url>https://github.com/codelibs/nekohtml</url>
 	<inceptionYear>2012</inceptionYear>
 	<licenses>
@@ -44,7 +44,7 @@
 				<version>3.14.0</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
-					<release>11</release>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -196,9 +196,21 @@
 			<version>2.12.1-sp1</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.11.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.14.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.14.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/codelibs/nekohtml/HTMLAugmentations.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLAugmentations.java
@@ -47,6 +47,9 @@ public class HTMLAugmentations implements Augmentations {
     //
     // Public methods
     //
+    /**
+     * Constructs an empty HTMLAugmentations object.
+     */
     public HTMLAugmentations() {
         // nothing
     }

--- a/src/main/java/org/codelibs/nekohtml/HTMLConfiguration.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLConfiguration.java
@@ -214,6 +214,11 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
 
     } // <init>()
 
+    /**
+     * Creates a new document scanner for HTML parsing.
+     * 
+     * @return a new HTMLScanner instance
+     */
     protected HTMLScanner createDocumentScanner() {
         return new HTMLScanner();
     }
@@ -444,7 +449,11 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
     // Protected methods
     //
 
-    /** Adds a component. */
+    /**
+     * Adds a component to the parser configuration.
+     * 
+     * @param component the HTML component to add
+     */
     protected void addComponent(final HTMLComponent component) {
 
         // add component to list
@@ -532,6 +541,12 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
      */
     protected class ErrorReporter implements HTMLErrorReporter {
 
+        /**
+         * Constructs an error reporter.
+         */
+        public ErrorReporter() {
+        }
+
         //
         // Data
         //
@@ -588,13 +603,25 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
         // Protected methods
         //
 
-        /** Creates parse exception. */
+        /**
+         * Creates a parse exception with a formatted message.
+         * 
+         * @param key the error message key
+         * @param args arguments to format into the message
+         * @return a new XMLParseException with the formatted message
+         */
         protected XMLParseException createException(final String key, final Object[] args) {
             final String message = formatMessage(key, args);
             return new XMLParseException(fDocumentScanner, message);
         } // createException(String,Object[]):XMLParseException
 
-        /** Format simple message. */
+        /**
+         * Formats a simple error message without localization.
+         * 
+         * @param key the error message key
+         * @param args arguments to include in the message
+         * @return the formatted simple error message
+         */
         protected String formatSimpleMessage(final String key, final Object[] args) {
             final StringBuilder str = new StringBuilder();
             str.append(ERROR_DOMAIN);

--- a/src/main/java/org/codelibs/nekohtml/HTMLElements.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLElements.java
@@ -17,6 +17,7 @@ package org.codelibs.nekohtml;
 
 /**
  * Collection of HTML element information.
+ * This class provides metadata and definitions for HTML elements used by the parser.
  *
  * @author Andy Clark
  * @author Ahmed Ashour
@@ -25,6 +26,13 @@ package org.codelibs.nekohtml;
  * @version $Id: HTMLElements.java,v 1.12 2005/02/14 07:16:59 andyc Exp $
  */
 public class HTMLElements {
+
+    /**
+     * Default constructor. This class serves as a static utility for HTML element definitions.
+     */
+    public HTMLElements() {
+        // Default constructor
+    }
 
     //
     // Constants
@@ -36,150 +44,295 @@ public class HTMLElements {
     //       sequence. The parent and closes references depends on
     //       this assumption. -Ac
 
+    /** Element code for A (anchor) element. */
     public static final short A = 0;
+    /** Element code for ABBR (abbreviation) element. */
     public static final short ABBR = A + 1;
+    /** Element code for ACRONYM element. */
     public static final short ACRONYM = ABBR + 1;
+    /** Element code for ADDRESS element. */
     public static final short ADDRESS = ACRONYM + 1;
+    /** Element code for APPLET element. */
     public static final short APPLET = ADDRESS + 1;
+    /** Element code for AREA element. */
     public static final short AREA = APPLET + 1;
+    /** Element code for ARTICLE element. */
     public static final short ARTICLE = AREA + 1;
+    /** Element code for ASIDE element. */
     public static final short ASIDE = ARTICLE + 1;
+    /** Element code for AUDIO element. */
     public static final short AUDIO = ASIDE + 1;
+    /** Element code for B (bold) element. */
     public static final short B = AUDIO + 1;
+    /** Element code for BASE element. */
     public static final short BASE = B + 1;
+    /** Element code for BASEFONT element. */
     public static final short BASEFONT = BASE + 1;
+    /** Element code for BDI (bidirectional isolate) element. */
     public static final short BDI = BASEFONT + 1;
+    /** Element code for BDO (bidirectional override) element. */
     public static final short BDO = BDI + 1;
+    /** Element code for BGSOUND element. */
     public static final short BGSOUND = BDO + 1;
+    /** Element code for BIG element. */
     public static final short BIG = BGSOUND + 1;
+    /** Element code for BLINK element. */
     public static final short BLINK = BIG + 1;
+    /** Element code for BLOCKQUOTE element. */
     public static final short BLOCKQUOTE = BLINK + 1;
+    /** Element code for BODY element. */
     public static final short BODY = BLOCKQUOTE + 1;
+    /** Element code for BR (line break) element. */
     public static final short BR = BODY + 1;
+    /** Element code for BUTTON element. */
     public static final short BUTTON = BR + 1;
+    /** Element code for CANVAS element. */
     public static final short CANVAS = BUTTON + 1;
+    /** Element code for CAPTION element. */
     public static final short CAPTION = CANVAS + 1;
+    /** Element code for CENTER element. */
     public static final short CENTER = CAPTION + 1;
+    /** Element code for CITE element. */
     public static final short CITE = CENTER + 1;
+    /** Element code for CODE element. */
     public static final short CODE = CITE + 1;
+    /** Element code for COL (column) element. */
     public static final short COL = CODE + 1;
+    /** Element code for COLGROUP (column group) element. */
     public static final short COLGROUP = COL + 1;
+    /** Element code for COMMENT element. */
     public static final short COMMENT = COLGROUP + 1;
+    /** Element code for DATA element. */
     public static final short DATA = COMMENT + 1;
+    /** Element code for DATALIST element. */
     public static final short DATALIST = DATA + 1;
+    /** Element code for DEL (deleted text) element. */
     public static final short DEL = DATALIST + 1;
+    /** Element code for DETAILS element. */
     public static final short DETAILS = DEL + 1;
+    /** Element code for DFN (definition) element. */
     public static final short DFN = DETAILS + 1;
+    /** Element code for DIALOG element. */
     public static final short DIALOG = DFN + 1;
+    /** Element code for DIR (directory) element. */
     public static final short DIR = DIALOG + 1;
+    /** Element code for DIV element. */
     public static final short DIV = DIR + 1;
+    /** Element code for DD (description definition) element. */
     public static final short DD = DIV + 1;
+    /** Element code for DL (description list) element. */
     public static final short DL = DD + 1;
+    /** Element code for DT (description term) element. */
     public static final short DT = DL + 1;
+    /** Element code for EM (emphasis) element. */
     public static final short EM = DT + 1;
+    /** Element code for EMBED element. */
     public static final short EMBED = EM + 1;
+    /** Element code for FIELDSET element. */
     public static final short FIELDSET = EMBED + 1;
+    /** Element code for FIGCAPTION element. */
     public static final short FIGCAPTION = FIELDSET + 1;
+    /** Element code for FIGURE element. */
     public static final short FIGURE = FIGCAPTION + 1;
+    /** Element code for FONT element. */
     public static final short FONT = FIGURE + 1;
+    /** Element code for FOOTER element. */
     public static final short FOOTER = FONT + 1;
+    /** Element code for FORM element. */
     public static final short FORM = FOOTER + 1;
+    /** Element code for FRAME element. */
     public static final short FRAME = FORM + 1;
+    /** Element code for FRAMESET element. */
     public static final short FRAMESET = FRAME + 1;
+    /** Element code for H1 (heading level 1) element. */
     public static final short H1 = FRAMESET + 1;
+    /** Element code for H2 (heading level 2) element. */
     public static final short H2 = H1 + 1;
+    /** Element code for H3 (heading level 3) element. */
     public static final short H3 = H2 + 1;
+    /** Element code for H4 (heading level 4) element. */
     public static final short H4 = H3 + 1;
+    /** Element code for H5 (heading level 5) element. */
     public static final short H5 = H4 + 1;
+    /** Element code for H6 (heading level 6) element. */
     public static final short H6 = H5 + 1;
+    /** Element code for HEAD element. */
     public static final short HEAD = H6 + 1;
+    /** Element code for HEADER element. */
     public static final short HEADER = HEAD + 1;
+    /** Element code for HR (horizontal rule) element. */
     public static final short HR = HEADER + 1;
+    /** Element code for HTML element. */
     public static final short HTML = HR + 1;
+    /** Element code for I (italic) element. */
     public static final short I = HTML + 1;
+    /** Element code for IFRAME (inline frame) element. */
     public static final short IFRAME = I + 1;
+    /** Element code for ILAYER element. */
     public static final short ILAYER = IFRAME + 1;
+    /** Element code for IMG (image) element. */
     public static final short IMG = ILAYER + 1;
+    /** Element code for INPUT element. */
     public static final short INPUT = IMG + 1;
+    /** Element code for INS (inserted text) element. */
     public static final short INS = INPUT + 1;
+    /** Element code for ISINDEX element. */
     public static final short ISINDEX = INS + 1;
+    /** Element code for KBD (keyboard input) element. */
     public static final short KBD = ISINDEX + 1;
+    /** Element code for KEYGEN element. */
     public static final short KEYGEN = KBD + 1;
+    /** Element code for LABEL element. */
     public static final short LABEL = KEYGEN + 1;
+    /** Element code for LAYER element. */
     public static final short LAYER = LABEL + 1;
+    /** Element code for LEGEND element. */
     public static final short LEGEND = LAYER + 1;
+    /** Element code for LI (list item) element. */
     public static final short LI = LEGEND + 1;
+    /** Element code for LINK element. */
     public static final short LINK = LI + 1;
+    /** Element code for LISTING element. */
     public static final short LISTING = LINK + 1;
+    /** Element code for MAIN element. */
     public static final short MAIN = LISTING + 1;
+    /** Element code for MAP element. */
     public static final short MAP = MAIN + 1;
+    /** Element code for MARK element. */
     public static final short MARK = MAP + 1;
+    /** Element code for MARQUEE element. */
     public static final short MARQUEE = MARK + 1;
+    /** Element code for MENU element. */
     public static final short MENU = MARQUEE + 1;
+    /** Element code for META element. */
     public static final short META = MENU + 1;
+    /** Element code for METER element. */
     public static final short METER = META + 1;
+    /** Element code for MULTICOL element. */
     public static final short MULTICOL = METER + 1;
+    /** Element code for NAV (navigation) element. */
     public static final short NAV = MULTICOL + 1;
+    /** Element code for NEXTID element. */
     public static final short NEXTID = NAV + 1;
+    /** Element code for NOBR (no break) element. */
     public static final short NOBR = NEXTID + 1;
+    /** Element code for NOEMBED element. */
     public static final short NOEMBED = NOBR + 1;
+    /** Element code for NOFRAMES element. */
     public static final short NOFRAMES = NOEMBED + 1;
+    /** Element code for NOLAYER element. */
     public static final short NOLAYER = NOFRAMES + 1;
+    /** Element code for NOSCRIPT element. */
     public static final short NOSCRIPT = NOLAYER + 1;
+    /** Element code for OBJECT element. */
     public static final short OBJECT = NOSCRIPT + 1;
+    /** Element code for OL (ordered list) element. */
     public static final short OL = OBJECT + 1;
+    /** Element code for OPTION element. */
     public static final short OPTION = OL + 1;
+    /** Element code for OPTGROUP (option group) element. */
     public static final short OPTGROUP = OPTION + 1;
+    /** Element code for OUTPUT element. */
     public static final short OUTPUT = OPTGROUP + 1;
+    /** Element code for P (paragraph) element. */
     public static final short P = OUTPUT + 1;
+    /** Element code for PARAM element. */
     public static final short PARAM = P + 1;
+    /** Element code for PICTURE element. */
     public static final short PICTURE = PARAM + 1;
+    /** Element code for PLAINTEXT element. */
     public static final short PLAINTEXT = PICTURE + 1;
+    /** Element code for PRE (preformatted text) element. */
     public static final short PRE = PLAINTEXT + 1;
+    /** Element code for PROGRESS element. */
     public static final short PROGRESS = PRE + 1;
+    /** Element code for Q (quotation) element. */
     public static final short Q = PROGRESS + 1;
+    /** Element code for RB (ruby base) element. */
     public static final short RB = Q + 1;
+    /** Element code for RBC (ruby base container) element. */
     public static final short RBC = RB + 1;
+    /** Element code for RP (ruby parentheses) element. */
     public static final short RP = RBC + 1;
+    /** Element code for RT (ruby text) element. */
     public static final short RT = RP + 1;
+    /** Element code for RTC (ruby text container) element. */
     public static final short RTC = RT + 1;
+    /** Element code for RUBY element. */
     public static final short RUBY = RTC + 1;
+    /** Element code for S (strikethrough) element. */
     public static final short S = RUBY + 1;
+    /** Element code for SAMP (sample output) element. */
     public static final short SAMP = S + 1;
+    /** Element code for SCRIPT element. */
     public static final short SCRIPT = SAMP + 1;
+    /** Element code for SECTION element. */
     public static final short SECTION = SCRIPT + 1;
+    /** Element code for SELECT element. */
     public static final short SELECT = SECTION + 1;
+    /** Element code for SMALL element. */
     public static final short SMALL = SELECT + 1;
+    /** Element code for SOUND element. */
     public static final short SOUND = SMALL + 1;
+    /** Element code for SOURCE element. */
     public static final short SOURCE = SOUND + 1;
+    /** Element code for SPACER element. */
     public static final short SPACER = SOURCE + 1;
+    /** Element code for SPAN element. */
     public static final short SPAN = SPACER + 1;
+    /** Element code for STRIKE element. */
     public static final short STRIKE = SPAN + 1;
+    /** Element code for STRONG element. */
     public static final short STRONG = STRIKE + 1;
+    /** Element code for STYLE element. */
     public static final short STYLE = STRONG + 1;
+    /** Element code for SUB (subscript) element. */
     public static final short SUB = STYLE + 1;
+    /** Element code for SUMMARY element. */
     public static final short SUMMARY = SUB + 1;
+    /** Element code for SUP (superscript) element. */
     public static final short SUP = SUMMARY + 1;
+    /** Element code for TABLE element. */
     public static final short TABLE = SUP + 1;
+    /** Element code for TEMPLATE element. */
     public static final short TEMPLATE = TABLE + 1;
+    /** Element code for TBODY (table body) element. */
     public static final short TBODY = TEMPLATE + 1;
+    /** Element code for TD (table data cell) element. */
     public static final short TD = TBODY + 1;
+    /** Element code for TEXTAREA element. */
     public static final short TEXTAREA = TD + 1;
+    /** Element code for TFOOT (table footer) element. */
     public static final short TFOOT = TEXTAREA + 1;
+    /** Element code for TH (table header cell) element. */
     public static final short TH = TFOOT + 1;
+    /** Element code for THEAD (table header) element. */
     public static final short THEAD = TH + 1;
+    /** Element code for TIME element. */
     public static final short TIME = THEAD + 1;
+    /** Element code for TITLE element. */
     public static final short TITLE = TIME + 1;
+    /** Element code for TR (table row) element. */
     public static final short TR = TITLE + 1;
+    /** Element code for TRACK element. */
     public static final short TRACK = TR + 1;
+    /** Element code for TT (teletype text) element. */
     public static final short TT = TRACK + 1;
+    /** Element code for U (underline) element. */
     public static final short U = TT + 1;
+    /** Element code for UL (unordered list) element. */
     public static final short UL = U + 1;
+    /** Element code for VAR (variable) element. */
     public static final short VAR = UL + 1;
+    /** Element code for VIDEO element. */
     public static final short VIDEO = VAR + 1;
+    /** Element code for WBR (word break opportunity) element. */
     public static final short WBR = VIDEO + 1;
+    /** Element code for XML element. */
     public static final short XML = WBR + 1;
+    /** Element code for XMP (example) element. */
     public static final short XMP = XML + 1;
+    /** Element code for unknown/unrecognized elements. */
     public static final short UNKNOWN = XMP + 1;
 
     // information
@@ -557,6 +710,7 @@ public class HTMLElements {
      * Returns the element information for the specified element code.
      *
      * @param code The element code.
+     * @return the element information for the specified code
      */
     public static final Element getElement(final short code) {
         return ELEMENTS.data[code];
@@ -566,6 +720,7 @@ public class HTMLElements {
      * Returns the element information for the specified element name.
      *
      * @param ename The element name.
+     * @return the element information for the specified name
      */
     public static final Element getElement(final String ename) {
         Element element = getElement(ename, NO_SUCH_ELEMENT);
@@ -582,6 +737,7 @@ public class HTMLElements {
      *
      * @param ename The element name.
      * @param element The default element to return if not found.
+     * @return the element information for the specified name, or the default element if not found
      */
     public static final Element getElement(final String ename, final Element element) {
 
@@ -684,6 +840,7 @@ public class HTMLElements {
          * @param name The element name.
          * @param flags Informational flags
          * @param parent Natural closing parent name.
+         * @param bounds Element boundary code for special parsing rules.
          * @param closes List of elements this element can close.
          */
         public Element(final short code, final String name, final int flags, final short parent, final short bounds, final short[] closes) {
@@ -710,6 +867,7 @@ public class HTMLElements {
          * @param name The element name.
          * @param flags Informational flags
          * @param parents Natural closing parent names.
+         * @param bounds Element boundary code for special parsing rules.
          * @param closes List of elements this element can close.
          */
         public Element(final short code, final String name, final int flags, final short[] parents, final short bounds, final short[] closes) {
@@ -726,22 +884,34 @@ public class HTMLElements {
         // Public methods
         //
 
-        /** Returns true if this element is an inline element. */
+        /**
+         * Returns true if this element is an inline element.
+         * @return true if this is an inline element, false otherwise
+         */
         public final boolean isInline() {
             return (flags & INLINE) != 0;
         } // isInline():boolean
 
-        /** Returns true if this element is a block element. */
+        /**
+         * Returns true if this element is a block element.
+         * @return true if this is a block element, false otherwise
+         */
         public final boolean isBlock() {
             return (flags & BLOCK) != 0;
         } // isBlock():boolean
 
-        /** Returns true if this element is an empty element. */
+        /**
+         * Returns true if this element is an empty element.
+         * @return true if this is an empty element, false otherwise
+         */
         public final boolean isEmpty() {
             return (flags & EMPTY) != 0;
         } // isEmpty():boolean
 
-        /** Returns true if this element is a container element. */
+        /**
+         * Returns true if this element is a container element.
+         * @return true if this is a container element, false otherwise
+         */
         public final boolean isContainer() {
             return (flags & CONTAINER) != 0;
         } // isContainer():boolean
@@ -749,6 +919,7 @@ public class HTMLElements {
         /**
          * Returns true if this element is special -- if its content
          * should be parsed ignoring markup.
+         * @return true if this is a special element, false otherwise
          */
         public final boolean isSpecial() {
             return (flags & SPECIAL) != 0;
@@ -757,7 +928,8 @@ public class HTMLElements {
         /**
          * Returns true if this element can close the specified Element.
          *
-         * @param tag The element.
+         * @param tag The element code to check.
+         * @return true if this element can close the specified element
          */
         public boolean closes(final short tag) {
             if (closes != null) {
@@ -813,8 +985,18 @@ public class HTMLElements {
         }
     } // class Element
 
-    /** Unsynchronized list of elements. */
+    /**
+     * Unsynchronized list of elements.
+     * This class provides a simple dynamic array implementation for storing Element objects.
+     */
     public static class ElementList {
+
+        /**
+         * Default constructor. Initializes an empty element list with default capacity.
+         */
+        public ElementList() {
+            // Default constructor
+        }
 
         //
         // Data
@@ -830,7 +1012,10 @@ public class HTMLElements {
         // Public methods
         //
 
-        /** Adds an element to list, resizing if necessary. */
+        /**
+         * Adds an element to list, resizing if necessary.
+         * @param element The element to add to the list
+         */
         public void addElement(final Element element) {
             if (size == data.length) {
                 final Element[] newarray = new Element[size + 20];

--- a/src/main/java/org/codelibs/nekohtml/HTMLEntities.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLEntities.java
@@ -25,12 +25,20 @@ import java.util.stream.Collectors;
 
 /**
  * Pre-defined HTML entities.
+ * This class provides mappings between HTML entity names and their corresponding character values.
  *
  * @author Andy Clark
  *
  * @version $Id: HTMLEntities.java,v 1.5 2005/02/14 03:56:54 andyc Exp $
  */
 public class HTMLEntities {
+
+    /**
+     * Default constructor. This class provides static utility methods for HTML entity handling.
+     */
+    public HTMLEntities() {
+        // Default constructor
+    }
 
     //
     // Constants
@@ -77,6 +85,8 @@ public class HTMLEntities {
     /**
      * Returns the character associated to the given entity name, or
      * -1 if the name is not known.
+     * @param name The entity name to lookup
+     * @return The character value associated with the entity name, or -1 if not found
      */
     public static int get(final String name) {
         final String value = ENTITIES.get(name);
@@ -86,6 +96,8 @@ public class HTMLEntities {
     /**
      * Returns the name associated to the given character or null if
      * the character is not known.
+     * @param c The character value to lookup
+     * @return The entity name associated with the character, or null if not found
      */
     public static String get(final int c) {
         return SEITITNE.get(c);

--- a/src/main/java/org/codelibs/nekohtml/HTMLErrorReporter.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLErrorReporter.java
@@ -41,13 +41,29 @@ public interface HTMLErrorReporter {
     // HTMLErrorReporter methods
     //
 
-    /** Format message without reporting error. */
+    /**
+     * Formats an error message without reporting the error.
+     * 
+     * @param key the message key to format
+     * @param args arguments to substitute into the message
+     * @return the formatted error message
+     */
     String formatMessage(String key, Object[] args);
 
-    /** Reports a warning. */
+    /**
+     * Reports a warning message.
+     * 
+     * @param key the warning message key
+     * @param args arguments to substitute into the message
+     */
     void reportWarning(String key, Object[] args);
 
-    /** Reports an error. */
+    /**
+     * Reports an error message.
+     * 
+     * @param key the error message key
+     * @param args arguments to substitute into the message
+     */
     void reportError(String key, Object[] args);
 
 } // interface HTMLErrorReporter

--- a/src/main/java/org/codelibs/nekohtml/HTMLEventInfo.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLEventInfo.java
@@ -31,27 +31,48 @@ public interface HTMLEventInfo {
 
     // location information
 
-    /** Returns the line number of the beginning of this event.*/
+    /**
+     * Returns the line number of the beginning of this event.
+     * @return The line number where this event begins
+     */
     int getBeginLineNumber();
 
-    /** Returns the column number of the beginning of this event.*/
+    /**
+     * Returns the column number of the beginning of this event.
+     * @return The column number where this event begins
+     */
     int getBeginColumnNumber();
 
-    /** Returns the character offset of the beginning of this event.*/
+    /**
+     * Returns the character offset of the beginning of this event.
+     * @return The character offset where this event begins
+     */
     int getBeginCharacterOffset();
 
-    /** Returns the line number of the end of this event.*/
+    /**
+     * Returns the line number of the end of this event.
+     * @return The line number where this event ends
+     */
     int getEndLineNumber();
 
-    /** Returns the column number of the end of this event.*/
+    /**
+     * Returns the column number of the end of this event.
+     * @return The column number where this event ends
+     */
     int getEndColumnNumber();
 
-    /** Returns the character offset of the end of this event.*/
+    /**
+     * Returns the character offset of the end of this event.
+     * @return The character offset where this event ends
+     */
     int getEndCharacterOffset();
 
     // other information
 
-    /** Returns true if this corresponding event was synthesized. */
+    /**
+     * Returns true if this corresponding event was synthesized.
+     * @return true if the event was synthesized, false otherwise
+     */
     boolean isSynthesized();
 
     /**
@@ -60,6 +81,13 @@ public interface HTMLEventInfo {
      * @author Andy Clark
      */
     class SynthesizedItem implements HTMLEventInfo {
+
+        /**
+         * Default constructor. Creates a synthesized event info item.
+         */
+        public SynthesizedItem() {
+            // Default constructor
+        }
 
         //
         // HTMLEventInfo methods

--- a/src/main/java/org/codelibs/nekohtml/HTMLScanner.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLScanner.java
@@ -94,6 +94,13 @@ import org.codelibs.nekohtml.xercesbridge.XercesBridge;
  */
 public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponent {
 
+    /**
+     * Default constructor. Creates an HTML scanner with default settings.
+     */
+    public HTMLScanner() {
+        // Default constructor
+    }
+
     //
     // Constants
     //
@@ -883,7 +890,12 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
     // Protected static methods
     //
 
-    /** Returns the value of the specified attribute, ignoring case. */
+    /**
+     * Returns the value of the specified attribute, ignoring case.
+     * @param attrs The attributes to search
+     * @param aname The attribute name to search for
+     * @return The attribute value or null if not found
+     */
     protected static String getValue(final XMLAttributes attrs, final String aname) {
         final int length = attrs != null ? attrs.getLength() : 0;
         for (int i = 0; i < length; i++) {
@@ -901,6 +913,7 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
      * indicates a failure to expand the id.
      *
      * @param systemId The systemId to be expanded.
+     * @param baseSystemId The base system identifier for resolving relative URIs.
      *
      * @return Returns the URI string representing the expanded system
      *         identifier. A null value indicates that the given
@@ -1009,7 +1022,12 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
 
     } // fixURI(String):String
 
-    /** Modifies the given name based on the specified mode. */
+    /**
+     * Modifies the given name based on the specified mode.
+     * @param name The name to modify
+     * @param mode The modification mode (NAMES_UPPERCASE, NAMES_LOWERCASE, or NAMES_NO_CHANGE)
+     * @return The modified name
+     */
     protected static final String modifyName(final String name, final short mode) {
         switch (mode) {
         case NAMES_UPPERCASE:
@@ -1024,6 +1042,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
     /**
      * Converts HTML names string value to constant value.
      *
+     * @param value The string value ("upper", "lower", or anything else for no change)
+     * @return The corresponding names mode constant
      * @see #NAMES_NO_CHANGE
      * @see #NAMES_LOWERCASE
      * @see #NAMES_UPPERCASE
@@ -1043,6 +1063,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
      * <p>
      * Details about this common problem can be found at
      * <a href='http://www.cs.tut.fi/~jkorpela/www/windows-chars.html'>http://www.cs.tut.fi/~jkorpela/www/windows-chars.html</a>
+     * @param origChar The original character code to fix
+     * @return The fixed character code
      */
     protected int fixWindowsCharacter(final int origChar) {
         /* PATCH: Asgeir Asgeirsson */
@@ -1105,26 +1127,39 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
     //
 
     // i/o
-    /** Reads a single character. */
+    /**
+     * Reads a single character.
+     * @return The character read as an integer, or -1 if end of stream
+     * @throws IOException If an I/O error occurs
+     */
     protected int read() throws IOException {
         return fCurrentEntity.read();
     }
 
     // debugging
 
-    /** Sets the scanner. */
+    /**
+     * Sets the scanner.
+     * @param scanner The scanner to set
+     */
     protected void setScanner(final Scanner scanner) {
         fScanner = scanner;
     } // setScanner(Scanner)
 
-    /** Sets the scanner state. */
+    /**
+     * Sets the scanner state.
+     * @param state The scanner state to set
+     */
     protected void setScannerState(final short state) {
         fScannerState = state;
     } // setScannerState(short)
 
     // scanning
 
-    /** Scans a DOCTYPE line. */
+    /**
+     * Scans a DOCTYPE line.
+     * @throws IOException If an I/O error occurs
+     */
     protected void scanDoctype() throws IOException {
         String root = null;
         String pubid = null;
@@ -1180,7 +1215,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
 
     } // scanDoctype()
 
-    /** Scans a quoted literal. */
+    /**
+     * Scans a quoted literal.
+     * @return The scanned literal string or null if no literal found
+     * @throws IOException If an I/O error occurs
+     */
     protected String scanLiteral() throws IOException {
         final int quote = fCurrentEntity.read();
         if (quote == '\'' || quote == '"') {
@@ -1215,7 +1254,12 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return null;
     } // scanLiteral():String
 
-    /** Scans a name. */
+    /**
+     * Scans a name.
+     * @param strict Whether to use strict name character validation
+     * @return The scanned name or null if no valid name found
+     * @throws IOException If an I/O error occurs
+     */
     protected String scanName(final boolean strict) throws IOException {
         if (fCurrentEntity.offset == fCurrentEntity.length) {
             if (fCurrentEntity.load(0) == -1) {
@@ -1249,7 +1293,13 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return name;
     } // scanName():String
 
-    /** Scans an entity reference. */
+    /**
+     * Scans an entity reference.
+     * @param str The string buffer to store the entity reference
+     * @param content Whether scanning within content context
+     * @return The entity character value or -1 if not a valid entity
+     * @throws IOException If an I/O error occurs
+     */
     protected int scanEntityRef(final XMLStringBuffer str, final boolean content) throws IOException {
         str.clear();
         str.append('&');
@@ -1378,7 +1428,13 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
 
     } // scanEntityRef(XMLStringBuffer,boolean):int
 
-    /** Returns true if the specified text is present and is skipped. */
+    /**
+     * Returns true if the specified text is present and is skipped.
+     * @param s The string to match and skip
+     * @param caseSensitive Whether the comparison should be case sensitive
+     * @return true if the string was matched and skipped, false otherwise
+     * @throws IOException If an I/O error occurs
+     */
     protected boolean skip(final String s, final boolean caseSensitive) throws IOException {
         final int length = s != null ? s.length() : 0;
         for (int i = 0; i < length; i++) {
@@ -1403,7 +1459,12 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return true;
     } // skip(String):boolean
 
-    /** Skips markup. */
+    /**
+     * Skips markup.
+     * @param balance Whether to balance opening and closing angle brackets
+     * @return true if markup was successfully skipped, false otherwise
+     * @throws IOException If an I/O error occurs
+     */
     protected boolean skipMarkup(final boolean balance) throws IOException {
         int depth = 1;
         boolean slashgt = false;
@@ -1447,7 +1508,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return slashgt;
     } // skipMarkup():boolean
 
-    /** Skips whitespace. */
+    /**
+     * Skips whitespace.
+     * @return true if any whitespace was skipped, false otherwise
+     * @throws IOException If an I/O error occurs
+     */
     protected boolean skipSpaces() throws IOException {
         boolean spaces = false;
         while (true) {
@@ -1471,7 +1536,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return spaces;
     } // skipSpaces()
 
-    /** Skips newlines and returns the number of newlines skipped. */
+    /**
+     * Skips newlines and returns the number of newlines skipped.
+     * @return The number of newlines skipped
+     * @throws IOException If an I/O error occurs
+     */
     protected int skipNewlines() throws IOException {
         if (!fCurrentEntity.hasNext()) {
             if (fCurrentEntity.load(0) == -1) {
@@ -1515,7 +1584,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
 
     // infoset utility methods
 
-    /** Returns an augmentations object with a location item added. */
+    /**
+     * Returns an augmentations object with a location item added.
+     * @return Augmentations object with location information
+     */
     protected final Augmentations locationAugs() {
         HTMLAugmentations augs = null;
         if (fAugmentations) {
@@ -1528,7 +1600,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return augs;
     } // locationAugs():Augmentations
 
-    /** Returns an augmentations object with a synthesized item added. */
+    /**
+     * Returns an augmentations object with a synthesized item added.
+     * @return Augmentations object marked as synthesized
+     */
     protected final Augmentations synthesizedAugs() {
         HTMLAugmentations augs = null;
         if (fAugmentations) {
@@ -1539,7 +1614,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return augs;
     } // synthesizedAugs():Augmentations
 
-    /** Returns an empty resource identifier. */
+    /**
+     * Returns an empty resource identifier.
+     * @return An empty XMLResourceIdentifier
+     */
     protected final XMLResourceIdentifier resourceId() {
         /***/
         fResourceId.clear();
@@ -1556,7 +1634,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
     // Protected static methods
     //
 
-    /** Returns true if the name is a built-in XML general entity reference. */
+    /**
+     * Returns true if the name is a built-in XML general entity reference.
+     * @param name The entity name to check
+     * @return true if the name is a built-in XML entity reference
+     */
     protected static boolean builtinXmlRef(final String name) {
         return "amp".equals(name) || "lt".equals(name) || "gt".equals(name) || "quot".equals(name) || "apos".equals(name);
     } // builtinXmlRef(String):boolean
@@ -1691,7 +1773,15 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         // Constructors
         //
 
-        /** Constructs an entity from the specified stream. */
+        /**
+         * Constructs an entity from the specified stream.
+         * @param stream The input stream reader
+         * @param encoding The character encoding
+         * @param publicId The public identifier
+         * @param baseSystemId The base system identifier
+         * @param literalSystemId The literal system identifier
+         * @param expandedSystemId The expanded system identifier
+         */
         public CurrentEntity(final Reader stream, final String encoding, final String publicId, final String baseSystemId,
                 final String literalSystemId, final String expandedSystemId) {
             stream_ = stream;
@@ -1736,6 +1826,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          * characters loaded or -1 if no additional characters were loaded.
          *
          * @param offset The offset at which new characters should be loaded.
+         * @return The number of characters loaded or -1 if no more characters
+         * @throws IOException If an I/O error occurs
          */
         protected int load(final int offset) throws IOException {
             // resize buffer, if needed
@@ -1755,7 +1847,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             return count;
         } // load():int
 
-        /** Reads a single character. */
+        /**
+         * Reads a single character.
+         * @return The character read as an integer, or -1 if end of stream
+         * @throws IOException If an I/O error occurs
+         */
         protected int read() throws IOException {
             if (offset == length) {
                 if (endReached_) {
@@ -1804,6 +1900,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             columnNumber_ = 1;
         }
 
+        /**
+         * Returns the current line number.
+         * @return The current line number
+         */
         public int getLineNumber() {
             return lineNumber_;
         }
@@ -1838,6 +1938,13 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
      * @author Andy Clark
      */
     public class ContentScanner implements Scanner {
+
+        /**
+         * Default constructor. Creates a content scanner.
+         */
+        public ContentScanner() {
+            // Default constructor
+        }
 
         //
         // Data
@@ -2075,6 +2182,7 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          * up to current offset.
          * @param len the number of characters to read
          * @return the read string (length may be smaller if EOF is encountered)
+         * @throws IOException If an I/O error occurs
          */
         protected String nextContent(final int len) throws IOException {
             final int originalOffset = fCurrentEntity.offset;
@@ -2106,7 +2214,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         // Protected methods
         //
 
-        /** Scans characters. */
+        /**
+         * Scans characters.
+         * @throws IOException If an I/O error occurs
+         */
         protected void scanCharacters() throws IOException {
             fStringBuffer.clear();
             while (true) {
@@ -2148,7 +2259,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
 
         } // scanCharacters()
 
-        /** Scans a CDATA section. */
+        /**
+         * Scans a CDATA section.
+         * @throws IOException If an I/O error occurs
+         */
         protected void scanCDATA() throws IOException {
             fStringBuffer.clear();
             if (fCDATASections) {
@@ -2181,7 +2295,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             }
         } // scanCDATA()
 
-        /** Scans a comment. */
+        /**
+         * Scans a comment.
+         * @throws IOException If an I/O error occurs
+         */
         protected void scanComment() throws IOException {
             fEndLineNumber = fCurrentEntity.getLineNumber();
             fEndColumnNumber = fCurrentEntity.getColumnNumber();
@@ -2226,7 +2343,13 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             }
         } // scanComment()
 
-        /** Scans markup content. */
+        /**
+         * Scans markup content.
+         * @param buffer The buffer to store the scanned content
+         * @param cend The character that marks the end of content
+         * @return true if EOF was encountered, false otherwise
+         * @throws IOException If an I/O error occurs
+         */
         protected boolean scanMarkupContent(final XMLStringBuffer buffer, final char cend) throws IOException {
             int c = -1;
             OUTER: while (true) {
@@ -2283,7 +2406,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             return c == -1;
         } // scanMarkupContent(XMLStringBuffer,char):boolean
 
-        /** Scans a processing instruction. */
+        /**
+         * Scans a processing instruction.
+         * @throws IOException If an I/O error occurs
+         */
         protected void scanPI() throws IOException {
             if (fReportErrors) {
                 fErrorReporter.reportWarning("HTML1008", null);
@@ -2395,6 +2521,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          *
          * @param empty Is used for a second return value to indicate whether
          *              the start element tag is empty (e.g. "/&gt;").
+         * @return The element name or null if invalid
+         * @throws IOException If an I/O error occurs
          */
         protected String scanStartElement(final boolean[] empty) throws IOException {
             String ename = scanName(true);
@@ -2548,6 +2676,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          * @param empty      Is used for a second return value to indicate
          *                   whether the start element tag is empty
          *                   (e.g. "/&gt;").
+         * @return true if an attribute was scanned, false otherwise
+         * @throws IOException If an I/O error occurs
          */
         protected boolean scanAttribute(final XMLAttributesImpl attributes, final boolean[] empty) throws IOException {
             return scanAttribute(attributes, empty, '/');
@@ -2557,6 +2687,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          * Scans a pseudo attribute.
          *
          * @param attributes The list of attributes.
+         * @return true if a pseudo attribute was scanned, false otherwise
+         * @throws IOException If an I/O error occurs
          */
         protected boolean scanPseudoAttribute(final XMLAttributesImpl attributes) throws IOException {
             return scanAttribute(attributes, fSingleBoolean, '?');
@@ -2571,8 +2703,8 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
          *                   (e.g. "/&gt;").
          * @param endc       The end character that appears before the
          *                   closing angle bracket ('&gt;').
-         * @return
-         * @throws IOException
+         * @return true if an attribute was scanned, false otherwise
+         * @throws IOException If an I/O error occurs
          */
         protected boolean scanAttribute(final XMLAttributesImpl attributes, final boolean[] empty, final char endc) throws IOException {
             final boolean skippedSpaces = skipSpaces();
@@ -2784,9 +2916,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             return true;
         } // scanAttribute(XMLAttributesImpl):boolean
 
-        /** Adds location augmentations to the specified attribute.
-         * @param attributes
-         * @param index
+        /**
+         * Adds location augmentations to the specified attribute.
+         * @param attributes The attributes collection
+         * @param index The attribute index
          */
         protected void addLocationItem(final XMLAttributes attributes, final int index) {
             fEndLineNumber = fCurrentEntity.getLineNumber();
@@ -2799,8 +2932,9 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             augs.putItem(AUGMENTATIONS, locationItem);
         } // addLocationItem(XMLAttributes,int)
 
-        /** Scans an end element.
-         * @throws IOException
+        /**
+         * Scans an end element.
+         * @throws IOException If an I/O error occurs
          */
         protected void scanEndElement() throws IOException {
             String ename = scanName(true);
@@ -2868,10 +3002,27 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         private final XMLStringBuffer fStringBuffer = new XMLStringBuffer();
 
         //
+        // Constructors
+        //
+
+        /**
+         * Default constructor for SpecialScanner.
+         * Initializes the scanner for processing special HTML elements that require
+         * text-only content handling.
+         */
+        public SpecialScanner() {
+            // Default constructor
+        }
+
+        //
         // Public methods
         //
 
-        /** Sets the element name. */
+        /**
+         * Sets the element name.
+         * @param ename The element name
+         * @return This scanner instance
+         */
         public Scanner setElementName(final String ename) {
             fElementName = ename;
             fStyle = "STYLE".equalsIgnoreCase(fElementName);
@@ -2979,7 +3130,12 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         // Protected methods
         //
 
-        /** Scan characters. */
+        /**
+         * Scan characters.
+         * @param buffer The buffer to store scanned characters
+         * @param delimiter The delimiter character to stop scanning
+         * @throws IOException If an I/O error occurs
+         */
         protected void scanCharacters(final XMLStringBuffer buffer, final int delimiter) throws IOException {
             while (true) {
                 final int c = fCurrentEntity.read();
@@ -3085,7 +3241,10 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         // Constructors
         //
 
-        /** Constructor. */
+        /**
+         * Constructor.
+         * @param in The input stream to wrap
+         */
         public PlaybackInputStream(final InputStream in) {
             super(in);
         } // <init>(InputStream)
@@ -3094,7 +3253,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         // Public methods
         //
 
-        /** Detect encoding. */
+        /**
+         * Detect encoding.
+         * @param encodings Array to store detected encoding information
+         * @throws IOException If an I/O error occurs
+         */
         public void detectEncoding(final String[] encodings) throws IOException {
             if (fDetected) {
                 throw new IOException("Should not detect encoding twice.");
@@ -3269,6 +3432,9 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         //
         // Public methods
         //
+        /**
+         * Default constructor. Creates an empty location item.
+         */
         public LocationItem() {
             // nothing
         }
@@ -3278,7 +3444,15 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
                     other.fEndColumnNumber, other.fEndCharacterOffset);
         }
 
-        /** Sets the values of this item. */
+        /**
+         * Sets the values of this item.
+         * @param beginLine The beginning line number
+         * @param beginColumn The beginning column number
+         * @param beginOffset The beginning character offset
+         * @param endLine The ending line number
+         * @param endColumn The ending column number
+         * @param endOffset The ending character offset
+         */
         public void setValues(final int beginLine, final int beginColumn, final int beginOffset, final int endLine, final int endColumn,
                 final int endOffset) {
             fBeginLineNumber = beginLine;
@@ -3402,7 +3576,11 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
         return string.equals(s);
     }
 
-    /** Reads a single character, preserving the old buffer content */
+    /**
+     * Reads a single character, preserving the old buffer content
+     * @return The character read as an integer, or -1 if end of stream
+     * @throws IOException If an I/O error occurs
+     */
     protected int readPreservingBufferContent() throws IOException {
         if (fCurrentEntity.offset == fCurrentEntity.length) {
             if (fCurrentEntity.load(fCurrentEntity.length) < 1) {

--- a/src/main/java/org/codelibs/nekohtml/HTMLTagBalancer.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLTagBalancer.java
@@ -238,6 +238,7 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
     /** Augmentations. */
     private final HTMLAugmentations fInfosetAugs = new HTMLAugmentations();
 
+    /** Tag balancing listener for handling ignored elements. */
     protected HTMLTagBalancingListener tagBalancingListener;
     private final LostText lostText_ = new LostText();
 
@@ -251,6 +252,19 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
     private int fragmentContextStackSize_ = 0; // not 0 only when a fragment is parsed and fragmentContextStack_ is set
 
     private final List<ElementEntry> endElementsBuffer_ = new ArrayList<>();
+
+    //
+    // Constructors
+    //
+
+    /**
+     * Default constructor for HTMLTagBalancer.
+     * Initializes the tag balancer for processing HTML documents and fixing
+     * structural problems in malformed HTML.
+     */
+    public HTMLTagBalancer() {
+        // Default constructor
+    }
 
     //
     // HTMLComponent methods
@@ -1063,12 +1077,22 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
 
     // removed since Xerces-J 2.3.0
 
-    /** Start document. */
+    /** 
+     * Start document.
+     * @param locator The document locator
+     * @param encoding The character encoding
+     * @param augs Additional information that may include infoset augmentations
+     */
     public void startDocument(final XMLLocator locator, final String encoding, final Augmentations augs) {
         startDocument(locator, encoding, null, augs);
     } // startDocument(XMLLocator,String,Augmentations)
 
-    /** Start prefix mapping. */
+    /** 
+     * Start prefix mapping.
+     * @param prefix The namespace prefix
+     * @param uri The namespace URI
+     * @param augs Additional information that may include infoset augmentations
+     */
     public void startPrefixMapping(final String prefix, final String uri, final Augmentations augs) {
 
         // check for end of document
@@ -1083,7 +1107,11 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
 
     } // startPrefixMapping(String,String,Augmentations)
 
-    /** End prefix mapping. */
+    /** 
+     * End prefix mapping.
+     * @param prefix The namespace prefix
+     * @param augs Additional information that may include infoset augmentations
+     */
     public void endPrefixMapping(final String prefix, final Augmentations augs) {
 
         // check for end of document
@@ -1102,7 +1130,11 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
     // Protected methods
     //
 
-    /** Returns an HTML element. */
+    /** 
+     * Returns an HTML element.
+     * @param elementName The qualified name of the element
+     * @return The HTML element descriptor for the given name
+     */
     protected HTMLElements.Element getElement(final QName elementName) {
         String name = elementName.rawname;
         if (fNamespaces && NamespaceBinder.XHTML_1_0_URI.equals(elementName.uri)) {
@@ -1114,12 +1146,21 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
         return HTMLElements.getElement(name);
     } // getElement(String):HTMLElements.Element
 
-    /** Call document handler start element. */
+    /** 
+     * Call document handler start element.
+     * @param element The element name
+     * @param attrs The element attributes
+     * @param augs Additional information that may include infoset augmentations
+     */
     protected final void callStartElement(final QName element, final XMLAttributes attrs, final Augmentations augs) {
         fDocumentHandler.startElement(element, attrs, augs);
     } // callStartElement(QName,XMLAttributes,Augmentations)
 
-    /** Call document handler end element. */
+    /** 
+     * Call document handler end element.
+     * @param element The element name
+     * @param augs Additional information that may include infoset augmentations
+     */
     protected final void callEndElement(final QName element, final Augmentations augs) {
         fDocumentHandler.endElement(element, augs);
     } // callEndElement(QName,Augmentations)
@@ -1129,6 +1170,7 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
      * element name or -1 if no matching element is found.
      *
      * @param element The element.
+     * @return The depth of the element in the stack, or -1 if not found
      */
     protected final int getElementDepth(final HTMLElements.Element element) {
         final boolean container = element.isContainer();
@@ -1162,6 +1204,8 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
      * element parent names or -1 if no matching element is found.
      *
      * @param parents The parent elements.
+     * @param bounds The bounds for parent element matching
+     * @return The depth of the first matching parent element, or -1 if not found
      */
     protected int getParentDepth(final HTMLElements.Element[] parents, final short bounds) {
         if (parents != null) {
@@ -1180,13 +1224,19 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
         return -1;
     } // getParentDepth(HTMLElements.Element[],short):int
 
-    /** Returns a set of empty attributes. */
+    /** 
+     * Returns a set of empty attributes.
+     * @return An empty XMLAttributes instance
+     */
     protected final XMLAttributes emptyAttributes() {
         fEmptyAttrs.removeAllAttributes();
         return fEmptyAttrs;
     } // emptyAttributes():XMLAttributes
 
-    /** Returns an augmentations object with a synthesized item added. */
+    /** 
+     * Returns an augmentations object with a synthesized item added.
+     * @return Augmentations object marked as synthesized
+     */
     protected final Augmentations synthesizedAugs() {
         HTMLAugmentations augs = null;
         if (fAugmentations) {
@@ -1201,7 +1251,12 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
     // Protected static methods
     //
 
-    /** Modifies the given name based on the specified mode. */
+    /** 
+     * Modifies the given name based on the specified mode.
+     * @param name The name to modify
+     * @param mode The modification mode (NAMES_UPPERCASE, NAMES_LOWERCASE, or NAMES_MATCH)
+     * @return The modified name
+     */
     protected static final String modifyName(final String name, final short mode) {
         switch (mode) {
         case NAMES_UPPERCASE:
@@ -1216,6 +1271,8 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
     /**
      * Converts HTML names string value to constant value.
      *
+     * @param value The string value to convert ("lower", "upper", or "match")
+     * @return The corresponding constant value
      * @see #NAMES_NO_CHANGE
      * @see #NAMES_LOWERCASE
      * @see #NAMES_UPPERCASE
@@ -1274,7 +1331,8 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
          * <strong>Note:</strong>
          * This constructor makes a copy of the element information.
          *
-         * @param element The element qualified name.
+         * @param element The HTML element descriptor.
+         * @param qname The element qualified name.
          */
         public Info(final HTMLElements.Element element, final QName qname) {
             this(element, qname, null);
@@ -1286,7 +1344,8 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
          * <strong>Note:</strong>
          * This constructor makes a copy of the element information.
          *
-         * @param element The element qualified name.
+         * @param element The HTML element descriptor.
+         * @param qname The element qualified name.
          * @param attributes The element attributes.
          */
         public Info(final HTMLElements.Element element, final QName qname, final XMLAttributes attributes) {
@@ -1335,10 +1394,25 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
         public Info[] data = new Info[10];
 
         //
+        // Constructors
+        //
+
+        /**
+         * Default constructor for InfoStack.
+         * Initializes an empty stack for storing element information.
+         */
+        public InfoStack() {
+            // Default constructor
+        }
+
+        //
         // Public methods
         //
 
-        /** Pushes element information onto the stack. */
+        /** 
+         * Pushes element information onto the stack.
+         * @param info The element information to push
+         */
         public void push(final Info info) {
             if (top == data.length) {
                 final Info[] newarray = new Info[top + 10];
@@ -1348,12 +1422,18 @@ public class HTMLTagBalancer implements XMLDocumentFilter, HTMLComponent {
             data[top++] = info;
         } // push(Info)
 
-        /** Peeks at the top of the stack. */
+        /** 
+         * Peeks at the top of the stack.
+         * @return The top element information without removing it
+         */
         public Info peek() {
             return data[top - 1];
         } // peek():Info
 
-        /** Pops the top item off of the stack. */
+        /** 
+         * Pops the top item off of the stack.
+         * @return The top element information after removing it
+         */
         public Info pop() {
             return data[--top];
         } // pop():Info

--- a/src/main/java/org/codelibs/nekohtml/HTMLTagBalancingListener.java
+++ b/src/main/java/org/codelibs/nekohtml/HTMLTagBalancingListener.java
@@ -32,11 +32,16 @@ import org.apache.xerces.xni.XMLAttributes;
 public interface HTMLTagBalancingListener {
     /**
      * Notifies that the start element has been ignored.
+     * @param elem The element name that was ignored
+     * @param attrs The element attributes
+     * @param augs Additional information that may include infoset augmentations
      */
     void ignoredStartElement(QName elem, XMLAttributes attrs, Augmentations augs);
 
     /**
      * Notifies that the end element has been ignored.
+     * @param element The element name that was ignored
+     * @param augs Additional information that may include infoset augmentations
      */
     void ignoredEndElement(QName element, Augmentations augs);
 

--- a/src/main/java/org/codelibs/nekohtml/filters/DefaultFilter.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/DefaultFilter.java
@@ -40,6 +40,12 @@ import org.codelibs.nekohtml.xercesbridge.XercesBridge;
  */
 public class DefaultFilter implements XMLDocumentFilter, HTMLComponent {
 
+    /**
+     * Constructs a default document filter.
+     */
+    public DefaultFilter() {
+    }
+
     //
     // Data
     //
@@ -218,19 +224,36 @@ public class DefaultFilter implements XMLDocumentFilter, HTMLComponent {
 
     // removed since Xerces-J 2.3.0
 
-    /** Start document. */
+    /**
+     * Start document.
+     * 
+     * @param locator the document locator
+     * @param encoding the document encoding
+     * @param augs additional augmentations information
+     */
     public void startDocument(final XMLLocator locator, final String encoding, final Augmentations augs) {
         startDocument(locator, encoding, null, augs);
     } // startDocument(XMLLocator,String,Augmentations)
 
-    /** Start prefix mapping. */
+    /**
+     * Start prefix mapping.
+     * 
+     * @param prefix the namespace prefix
+     * @param uri the namespace URI
+     * @param augs additional augmentations information
+     */
     public void startPrefixMapping(final String prefix, final String uri, final Augmentations augs) {
         if (fDocumentHandler != null) {
             XercesBridge.getInstance().XMLDocumentHandler_startPrefixMapping(fDocumentHandler, prefix, uri, augs);
         }
     } // startPrefixMapping(String,String,Augmentations)
 
-    /** End prefix mapping. */
+    /**
+     * End prefix mapping.
+     * 
+     * @param prefix the namespace prefix
+     * @param augs additional augmentations information
+     */
     public void endPrefixMapping(final String prefix, final Augmentations augs) {
         if (fDocumentHandler != null) {
             XercesBridge.getInstance().XMLDocumentHandler_endPrefixMapping(fDocumentHandler, prefix, augs);
@@ -330,6 +353,10 @@ public class DefaultFilter implements XMLDocumentFilter, HTMLComponent {
     /**
      * Utility method for merging string arrays for recognized features
      * and recognized properties.
+     * 
+     * @param array1 the first string array to merge
+     * @param array2 the second string array to merge
+     * @return a new array containing all elements from both input arrays
      */
     protected static String[] merge(final String[] array1, final String[] array2) {
 

--- a/src/main/java/org/codelibs/nekohtml/filters/ElementRemover.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/ElementRemover.java
@@ -91,6 +91,12 @@ import org.apache.xerces.xni.XMLString;
  */
 public class ElementRemover extends DefaultFilter {
 
+    /**
+     * Constructs an element remover filter.
+     */
+    public ElementRemover() {
+    }
+
     //
     // Constants
     //
@@ -302,19 +308,35 @@ public class ElementRemover extends DefaultFilter {
     // Protected methods
     //
 
-    /** Returns true if the specified element is accepted. */
+    /**
+     * Returns true if the specified element is accepted.
+     * 
+     * @param element the element name to check
+     * @return true if the element is accepted, false otherwise
+     */
     protected boolean elementAccepted(final String element) {
         final String key = element.toLowerCase();
         return fAcceptedElements.containsKey(key);
     } // elementAccepted(String):boolean
 
-    /** Returns true if the specified element should be removed. */
+    /**
+     * Returns true if the specified element should be removed.
+     * 
+     * @param element the element name to check
+     * @return true if the element should be removed, false otherwise
+     */
     protected boolean elementRemoved(final String element) {
         final String key = element.toLowerCase();
         return fRemovedElements.containsKey(key);
     } // elementRemoved(String):boolean
 
-    /** Handles an open tag. */
+    /**
+     * Handles an open tag.
+     * 
+     * @param element the element qualified name
+     * @param attributes the element attributes
+     * @return true if the element should be processed, false if it should be filtered out
+     */
     protected boolean handleOpenTag(final QName element, final XMLAttributes attributes) {
         if (elementAccepted(element.rawname)) {
             final String key = element.rawname.toLowerCase();

--- a/src/main/java/org/codelibs/nekohtml/filters/Identity.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/Identity.java
@@ -60,6 +60,19 @@ public class Identity extends DefaultFilter {
     protected static final String FILTERS = "http://cyberneko.org/html/properties/filters";
 
     //
+    // Constructors
+    //
+
+    /**
+     * Default constructor for Identity filter.
+     * Creates a filter that outputs only content that appeared in the original HTML document,
+     * filtering out any synthesized elements and structures added during parsing.
+     */
+    public Identity() {
+        // Default constructor
+    }
+
+    //
     // XMLDocumentHandler methods
     //
 
@@ -91,7 +104,11 @@ public class Identity extends DefaultFilter {
     // Protected static methods
     //
 
-    /** Returns true if the information provided is synthesized. */
+    /** 
+     * Returns true if the information provided is synthesized.
+     * @param augs The augmentations to check for synthesized content
+     * @return True if the content was synthesized during parsing, false otherwise
+     */
     protected static boolean synthesized(final Augmentations augs) {
         final HTMLEventInfo info = (HTMLEventInfo) augs.getItem(AUGMENTATIONS);
         return info != null && info.isSynthesized();

--- a/src/main/java/org/codelibs/nekohtml/filters/NamespaceBinder.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/NamespaceBinder.java
@@ -144,6 +144,19 @@ public class NamespaceBinder extends DefaultFilter {
     private final QName fQName = new QName();
 
     //
+    // Constructors
+    //
+
+    /**
+     * Default constructor for NamespaceBinder filter.
+     * Creates a filter that binds namespaces to HTML elements and attributes,
+     * supporting proper namespace handling in HTML documents.
+     */
+    public NamespaceBinder() {
+        // Default constructor
+    }
+
+    //
     // HTMLComponent methods
     //
 
@@ -330,7 +343,10 @@ public class NamespaceBinder extends DefaultFilter {
     // Protected static methods
     //
 
-    /** Splits a qualified name. */
+    /** 
+     * Splits a qualified name.
+     * @param qname The qualified name to split into prefix and local part
+     */
     protected static void splitQName(final QName qname) {
         final int index = qname.rawname.indexOf(':');
         if (index != -1) {
@@ -342,6 +358,8 @@ public class NamespaceBinder extends DefaultFilter {
     /**
      * Converts HTML names string value to constant value.
      *
+     * @param value The string value to convert ("lower", "upper", or other)
+     * @return The corresponding constant value
      * @see #NAMES_NO_CHANGE
      * @see #NAMES_LOWERCASE
      * @see #NAMES_UPPERCASE
@@ -356,7 +374,12 @@ public class NamespaceBinder extends DefaultFilter {
         return NAMES_NO_CHANGE;
     } // getNamesValue(String):short
 
-    /** Modifies the given name based on the specified mode. */
+    /** 
+     * Modifies the given name based on the specified mode.
+     * @param name The name to modify
+     * @param mode The modification mode (NAMES_UPPERCASE, NAMES_LOWERCASE, or NAMES_NO_CHANGE)
+     * @return The modified name
+     */
     protected static final String modifyName(final String name, final short mode) {
         switch (mode) {
         case NAMES_UPPERCASE:
@@ -372,7 +395,11 @@ public class NamespaceBinder extends DefaultFilter {
     // Protected methods
     //
 
-    /** Binds namespaces. */
+    /** 
+     * Binds namespaces.
+     * @param element The element name to bind namespaces for
+     * @param attrs The element attributes that may contain namespace declarations
+     */
     protected void bindNamespaces(final QName element, final XMLAttributes attrs) {
 
         // split element qname
@@ -522,7 +549,10 @@ public class NamespaceBinder extends DefaultFilter {
             return fEntries[fLevels[fTop - 1] + index].prefix;
         } // getDeclaredPrefixAt(int):String
 
-        /** Get parent context. */
+        /** 
+         * Get parent context.
+         * @return The parent namespace context
+         */
         public NamespaceContext getParentContext() {
             return this;
         } // getParentContext():NamespaceContext

--- a/src/main/java/org/codelibs/nekohtml/filters/Purifier.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/Purifier.java
@@ -140,6 +140,19 @@ public class Purifier extends DefaultFilter {
     private final XMLStringBuffer fStringBuffer = new XMLStringBuffer();
 
     //
+    // Constructors
+    //
+
+    /**
+     * Default constructor for Purifier filter.
+     * Creates a filter that ensures well-formed XML output by modifying names
+     * and content to comply with XML naming rules and character restrictions.
+     */
+    public Purifier() {
+        // Default constructor
+    }
+
+    //
     // XMLComponent methods
     //
 
@@ -308,7 +321,11 @@ public class Purifier extends DefaultFilter {
         fSeenRootElement = false;
     } // handleStartDocument()
 
-    /** Handle start element. */
+    /** 
+     * Handle start element.
+     * @param element The element name to process
+     * @param attrs The element attributes to process
+     */
     protected void handleStartElement(QName element, final XMLAttributes attrs) {
 
         // handle element and attributes
@@ -351,7 +368,11 @@ public class Purifier extends DefaultFilter {
 
     } // handleStartElement(QName,XMLAttributes)
 
-    /** Synthesize namespace binding. */
+    /** 
+     * Synthesize namespace binding.
+     * @param attrs The attributes to add the namespace binding to
+     * @param ns The namespace prefix to bind
+     */
     protected void synthesizeBinding(final XMLAttributes attrs, final String ns) {
         final String prefix = "xmlns";
         final String localpart = ns;
@@ -369,7 +390,10 @@ public class Purifier extends DefaultFilter {
 
     } // synthesizeBinding(XMLAttributes,String)
 
-    /** Returns an augmentations object with a synthesized item added. */
+    /** 
+     * Returns an augmentations object with a synthesized item added.
+     * @return Augmentations object marked as synthesized
+     */
     protected final Augmentations synthesizedAugs() {
         HTMLAugmentations augs = null;
         if (fAugmentations) {
@@ -384,7 +408,11 @@ public class Purifier extends DefaultFilter {
     // Protected methods
     //
 
-    /** Purify qualified name. */
+    /** 
+     * Purify qualified name.
+     * @param qname The qualified name to purify
+     * @return The purified qualified name
+     */
     protected QName purifyQName(final QName qname) {
         qname.prefix = purifyName(qname.prefix, true);
         qname.localpart = purifyName(qname.localpart, true);
@@ -392,7 +420,12 @@ public class Purifier extends DefaultFilter {
         return qname;
     } // purifyQName(QName):QName
 
-    /** Purify name. */
+    /** 
+     * Purify name.
+     * @param name The name to purify
+     * @param localpart True if this is a local part of a qualified name
+     * @return The purified name that conforms to XML naming rules
+     */
     protected String purifyName(final String name, final boolean localpart) {
         if (name == null) {
             return name;
@@ -420,7 +453,11 @@ public class Purifier extends DefaultFilter {
         return str.toString();
     } // purifyName(String):String
 
-    /** Purify content. */
+    /** 
+     * Purify content.
+     * @param text The text content to purify
+     * @return The purified text with invalid XML characters replaced
+     */
     protected XMLString purifyText(final XMLString text) {
         fStringBuffer.length = 0;
         for (int i = 0; i < text.length; i++) {
@@ -438,7 +475,12 @@ public class Purifier extends DefaultFilter {
     // Protected static methods
     //
 
-    /** Returns a padded hexadecimal string for the given value. */
+    /** 
+     * Returns a padded hexadecimal string for the given value.
+     * @param c The character value to convert to hexadecimal
+     * @param padlen The desired length of the resulting string (padded with zeros)
+     * @return The hexadecimal string representation
+     */
     protected static String toHexString(final int c, final int padlen) {
         final StringBuilder str = new StringBuilder(padlen);
         str.append(Integer.toHexString(c));

--- a/src/main/java/org/codelibs/nekohtml/filters/Writer.java
+++ b/src/main/java/org/codelibs/nekohtml/filters/Writer.java
@@ -129,6 +129,7 @@ public class Writer extends DefaultFilter {
      * @param outputStream The output stream to write to.
      * @param encoding The encoding to be used for the output. The encoding name
      *                 should be an official IANA encoding name.
+     * @throws UnsupportedEncodingException If the specified encoding is not supported
      */
     public Writer(final OutputStream outputStream, final String encoding) throws UnsupportedEncodingException {
         this(new OutputStreamWriter(outputStream, encoding), encoding);
@@ -276,7 +277,10 @@ public class Writer extends DefaultFilter {
     // Protected methods
     //
 
-    /** Print attribute value. */
+    /** 
+     * Print attribute value.
+     * @param text The attribute value text to print
+     */
     protected void printAttributeValue(final String text) {
         final int length = text.length();
         for (int j = 0; j < length; j++) {
@@ -290,7 +294,11 @@ public class Writer extends DefaultFilter {
         fPrinter.flush();
     } // printAttributeValue(String)
 
-    /** Print characters. */
+    /** 
+     * Print characters.
+     * @param text The character data to print
+     * @param normalize Whether to normalize the text by converting entities
+     */
     protected void printCharacters(final XMLString text, final boolean normalize) {
         if (normalize) {
             for (int i = 0; i < text.length; i++) {
@@ -315,7 +323,11 @@ public class Writer extends DefaultFilter {
         fPrinter.flush();
     } // printCharacters(XMLString,boolean)
 
-    /** Print start element. */
+    /** 
+     * Print start element.
+     * @param element The element name to print
+     * @param attributes The element attributes to print
+     */
     protected void printStartElement(final QName element, final XMLAttributes attributes) {
 
         // modify META[@http-equiv='content-type']/@content value
@@ -375,7 +387,10 @@ public class Writer extends DefaultFilter {
 
     } // printStartElement(QName,XMLAttributes)
 
-    /** Print end element. */
+    /** 
+     * Print end element.
+     * @param element The element name to print
+     */
     protected void printEndElement(final QName element) {
         fPrinter.print("</");
         fPrinter.print(element.rawname);
@@ -383,7 +398,10 @@ public class Writer extends DefaultFilter {
         fPrinter.flush();
     } // printEndElement(QName)
 
-    /** Print entity. */
+    /** 
+     * Print entity.
+     * @param name The entity name to print
+     */
     protected void printEntity(final String name) {
         fPrinter.print('&');
         fPrinter.print(name);
@@ -395,7 +413,11 @@ public class Writer extends DefaultFilter {
     // MAIN
     //
 
-    /** Main. */
+    /** 
+     * Main.
+     * @param argv Command line arguments
+     * @throws Exception If an error occurs during processing
+     */
     public static void main(final String[] argv) throws Exception {
         if (argv.length == 0) {
             printUsage();

--- a/src/main/java/org/codelibs/nekohtml/parsers/DOMFragmentParser.java
+++ b/src/main/java/org/codelibs/nekohtml/parsers/DOMFragmentParser.java
@@ -124,12 +124,26 @@ public class DOMFragmentParser implements XMLDocumentHandler {
     // Public methods
     //
 
-    /** Parses a document fragment. */
+    /**
+     * Parses a document fragment.
+     * 
+     * @param systemId the system identifier for the input source
+     * @param fragment the document fragment to populate with parsed content
+     * @throws SAXException if a SAX error occurs during parsing
+     * @throws IOException if an I/O error occurs during parsing
+     */
     public void parse(final String systemId, final DocumentFragment fragment) throws SAXException, IOException {
         parse(new InputSource(systemId), fragment);
     } // parse(String,DocumentFragment)
 
-    /** Parses a document fragment. */
+    /**
+     * Parses a document fragment.
+     * 
+     * @param source the input source containing the HTML content to parse
+     * @param fragment the document fragment to populate with parsed content
+     * @throws SAXException if a SAX error occurs during parsing
+     * @throws IOException if an I/O error occurs during parsing
+     */
     public void parse(final InputSource source, final DocumentFragment fragment) throws SAXException, IOException {
 
         fCurrentNode = fDocumentFragment = fragment;
@@ -335,7 +349,13 @@ public class DOMFragmentParser implements XMLDocumentHandler {
         return fDocumentSource;
     } // getDocumentSource():XMLDocumentSource
 
-    /** Start document. */
+    /**
+     * Start document.
+     * 
+     * @param locator the document locator
+     * @param encoding the document encoding
+     * @param augs additional augmentations information
+     */
     public void startDocument(final XMLLocator locator, final String encoding, final Augmentations augs) {
         startDocument(locator, encoding, null, augs);
     } // startDocument(XMLLocator,String,Augmentations)
@@ -376,11 +396,24 @@ public class DOMFragmentParser implements XMLDocumentHandler {
         fCurrentNode.appendChild(comment);
     } // comment(XMLString,Augmentations)
 
-    /** Start prefix mapping. @deprecated Since Xerces 2.2.0. */
+    /**
+     * Start prefix mapping.
+     * 
+     * @param prefix the namespace prefix
+     * @param uri the namespace URI
+     * @param augs additional augmentations information
+     * @deprecated Since Xerces 2.2.0.
+     */
     public void startPrefixMapping(final String prefix, final String uri, final Augmentations augs) {
     } // startPrefixMapping(String,String,Augmentations)
 
-    /** End prefix mapping. @deprecated Since Xerces 2.2.0. */
+    /**
+     * End prefix mapping.
+     * 
+     * @param prefix the namespace prefix
+     * @param augs additional augmentations information
+     * @deprecated Since Xerces 2.2.0.
+     */
     public void endPrefixMapping(final String prefix, final Augmentations augs) {
     } // endPrefixMapping(String,Augmentations)
 

--- a/src/main/java/org/codelibs/nekohtml/xercesbridge/XercesBridge.java
+++ b/src/main/java/org/codelibs/nekohtml/xercesbridge/XercesBridge.java
@@ -33,6 +33,14 @@ public abstract class XercesBridge {
     private static final XercesBridge instance = makeInstance();
 
     /**
+     * Default constructor for XercesBridge.
+     * Creates a bridge for handling version-specific Xerces implementation differences.
+     */
+    protected XercesBridge() {
+        // Protected constructor
+    }
+
+    /**
      * The access point for the bridge.
      * @return the instance corresponding to the Xerces version being currently used.
      */
@@ -67,9 +75,9 @@ public abstract class XercesBridge {
 
     /**
      * Default implementation does nothing
-     * @param namespaceContext
-     * @param ns
-     * @param avalue
+     * @param namespaceContext The namespace context to declare the prefix in
+     * @param ns The namespace prefix
+     * @param avalue The namespace URI value
      */
     public void NamespaceContext_declarePrefix(final NamespaceContext namespaceContext, final String ns, final String avalue) {
         // nothing
@@ -83,12 +91,21 @@ public abstract class XercesBridge {
 
     /**
      * Calls startDocument on the {@link XMLDocumentHandler}.
+     * @param documentHandler The document handler to call startDocument on
+     * @param locator The document locator
+     * @param encoding The character encoding
+     * @param nscontext The namespace context
+     * @param augs Additional information that may include infoset augmentations
      */
     public abstract void XMLDocumentHandler_startDocument(XMLDocumentHandler documentHandler, XMLLocator locator, String encoding,
             NamespaceContext nscontext, Augmentations augs);
 
     /**
      * Calls startPrefixMapping on the {@link XMLDocumentHandler}.
+     * @param documentHandler The document handler to call startPrefixMapping on
+     * @param prefix The namespace prefix
+     * @param uri The namespace URI
+     * @param augs Additional information that may include infoset augmentations
      */
     public void XMLDocumentHandler_startPrefixMapping(final XMLDocumentHandler documentHandler, final String prefix, final String uri,
             final Augmentations augs) {
@@ -97,6 +114,9 @@ public abstract class XercesBridge {
 
     /**
      * Calls endPrefixMapping on the {@link XMLDocumentHandler}.
+     * @param documentHandler The document handler to call endPrefixMapping on
+     * @param prefix The namespace prefix
+     * @param augs Additional information that may include infoset augmentations
      */
     public void XMLDocumentHandler_endPrefixMapping(final XMLDocumentHandler documentHandler, final String prefix, final Augmentations augs) {
         // default does nothing
@@ -105,6 +125,8 @@ public abstract class XercesBridge {
     /**
      * Calls setDocumentSource (if available in the Xerces version used) on the {@link XMLDocumentFilter}.
      * This implementation does nothing.
+     * @param filter The document filter to set the document source on
+     * @param lastSource The document source to set
      */
     public void XMLDocumentFilter_setDocumentSource(final XMLDocumentFilter filter, final XMLDocumentSource lastSource) {
         // nothing, it didn't exist on old Xerces versions

--- a/src/test/java/org/codelibs/nekohtml/CanonicalTest.java
+++ b/src/test/java/org/codelibs/nekohtml/CanonicalTest.java
@@ -32,10 +32,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.xni.parser.XMLDocumentFilter;
 import org.apache.xerces.xni.parser.XMLInputSource;
@@ -52,17 +56,17 @@ import org.codelibs.nekohtml.xercesbridge.XercesBridge;
  * @author Marc Guillemot
  * @author Ahmed Ashour
  */
-public class CanonicalTest extends TestCase {
+public class CanonicalTest {
 
     private static final File canonicalDir = new File("src/test/resources/data/canonical");
     private static final File outputDir = new File("target/build/data/output/" + XercesBridge.getInstance().getVersion());
     private File dataFile;
 
-    public static Test suite() throws Exception {
+    @TestFactory
+    Stream<DynamicTest> canonicalTests() throws Exception {
         outputDir.mkdirs();
 
-        TestSuite suite = new TestSuite();
-        final List/*File*/dataFiles = new ArrayList();
+        final List<File> dataFiles = new ArrayList<>();
         File dataDir = new File("src/test/resources/data");
         dataDir.listFiles(new FileFilter() {
             public boolean accept(final File file) {
@@ -77,18 +81,12 @@ public class CanonicalTest extends TestCase {
         });
         Collections.sort(dataFiles);
 
-        for (Object file : dataFiles) {
-            suite.addTest(new CanonicalTest((File) file));
-        }
-        return suite;
+        return dataFiles.stream().map(
+                dataFile -> DynamicTest.dynamicTest(dataFile.getName() + " [" + XercesBridge.getInstance().getVersion() + "]",
+                        () -> runCanonicalTest(dataFile)));
     }
 
-    CanonicalTest(final File dataFile) throws Exception {
-        super(dataFile.getName() + " [" + XercesBridge.getInstance().getVersion() + "]");
-        this.dataFile = dataFile;
-    }
-
-    protected void runTest() throws Exception {
+    private void runCanonicalTest(final File dataFile) throws Exception {
         final String dataLines = getResult(dataFile);
         try {
             // prepare for future changes where canonical files are next to test file
@@ -102,7 +100,7 @@ public class CanonicalTest extends TestCase {
             final String canonicalLines = getCanonical(canonicalFile);
 
             assertEquals(canonicalLines, dataLines);
-        } catch (final AssertionFailedError e) {
+        } catch (final AssertionError e) {
             final File output = new File(outputDir, dataFile.getName());
             final PrintWriter pw = new PrintWriter(new FileOutputStream(output));
             pw.print(dataLines);

--- a/src/test/java/org/codelibs/nekohtml/DOMFragmentParserTest.java
+++ b/src/test/java/org/codelibs/nekohtml/DOMFragmentParserTest.java
@@ -17,7 +17,9 @@ package org.codelibs.nekohtml;
 
 import java.io.StringReader;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.html.dom.HTMLDocumentImpl;
 import org.codelibs.nekohtml.parsers.DOMFragmentParser;
@@ -34,10 +36,11 @@ import org.xml.sax.InputSource;
  * @author Marc Guillemot
  *
  */
-public class DOMFragmentParserTest extends TestCase {
+public class DOMFragmentParserTest {
     /**
      * See <a href="https://sourceforge.net/p/nekohtml/bugs/154/">Bug 154</a>.
      */
+    @Test
     public void testAttrEndingWithCRAtEndOfStream() throws Exception {
         doTest("<a href=\"\r", "<A href=\"&#xa;\"/>");
     }
@@ -45,6 +48,7 @@ public class DOMFragmentParserTest extends TestCase {
     /**
      * See <a href="http://sourceforge.net/support/tracker.php?aid=2828553">Bug 2828553</a>.
      */
+    @Test
     public void testInvalidProcessingInstruction() throws Exception {
         doTest("<html><?9 ?></html>", "<HTML/>");
     }
@@ -52,6 +56,7 @@ public class DOMFragmentParserTest extends TestCase {
     /**
      * See <a href="http://sourceforge.net/support/tracker.php?aid=2828534">Bug 2828534</a>.
      */
+    @Test
     public void testInvalidAttributeName() throws Exception {
         doTest("<html 9='id'></html>", "<HTML/>");
     }
@@ -93,6 +98,7 @@ public class DOMFragmentParserTest extends TestCase {
      * HTMLTagBalancer field fSeenBodyElementEnd was not correctly reset as of 1.19.17  
      * @throws Exception
      */
+    @Test
     public void testInstanceReuse() throws Exception {
         final String s = "<html><body><frame><frameset></frameset></html>";
 

--- a/src/test/java/org/codelibs/nekohtml/FragmentContextStackTest.java
+++ b/src/test/java/org/codelibs/nekohtml/FragmentContextStackTest.java
@@ -18,7 +18,9 @@ package org.codelibs.nekohtml;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.xni.QName;
 import org.apache.xerces.xni.parser.XMLDocumentFilter;
@@ -33,8 +35,9 @@ import org.codelibs.nekohtml.parsers.DOMParser;
  * @version $Id: HTMLTagBalancingListenerTest.java 145 2008-03-17 18:18:33Z
  *          mguillem $
  */
-public class FragmentContextStackTest extends TestCase {
+public class FragmentContextStackTest {
 
+    @Test
     public void testSimple() throws Exception {
         String expected = "(DIV\n" + "(SPAN\n" + "\"hello\n" + ")SPAN\n" + ")DIV\n";
         doTest("<div><span>hello</span>", new String[] { "html", "body" }, expected);
@@ -45,6 +48,7 @@ public class FragmentContextStackTest extends TestCase {
         doTest("<div><span>hello</span>", null, expected);
     }
 
+    @Test
     public void testTR() throws Exception {
         String expected = "(TR\n" + "(TD\n" + "\"hello\n" + ")TD\n" + ")TR\n";
         doTest("<tr><td>hello</td></tr>", new String[] { "html", "body", "table", "tbody" }, expected);
@@ -53,6 +57,7 @@ public class FragmentContextStackTest extends TestCase {
         doTest("<tr><td>hello</td></tr>", new String[] { "html", "body" }, "\"hello");
     }
 
+    @Test
     public void testFragmentShouldNotCloseContextStack() throws Exception {
         String expected = "\"helloworld\n";
         doTest("hello</div>world", new String[] { "html", "body", "div" }, expected);

--- a/src/test/java/org/codelibs/nekohtml/HTMLScannerTest.java
+++ b/src/test/java/org/codelibs/nekohtml/HTMLScannerTest.java
@@ -34,7 +34,11 @@ import org.apache.xerces.xni.parser.XMLInputSource;
 import org.apache.xerces.xni.parser.XMLParserConfiguration;
 import org.codelibs.nekohtml.filters.DefaultFilter;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link HTMLScanner}.
@@ -42,8 +46,9 @@ import junit.framework.TestCase;
  * @author Ahmed Ashour
  * @version $Id: HTMLScanner.java,v 1.19 2005/06/14 05:52:37 andyc Exp $
  */
-public class HTMLScannerTest extends TestCase {
+public class HTMLScannerTest {
 
+    @Test
     public void testisEncodingCompatible() throws Exception {
         final HTMLScanner scanner = new HTMLScanner();
         assertTrue(scanner.isEncodingCompatible("ISO-8859-1", "ISO-8859-1"));
@@ -57,6 +62,7 @@ public class HTMLScannerTest extends TestCase {
         assertFalse(scanner.isEncodingCompatible("UTF-16", "Cp1252"));
     }
 
+    @Test
     public void testEvaluateInputSource() throws Exception {
         String string =
                 "<html><head><title>foo</title></head>" + "<body>" + "<script id='myscript'>"
@@ -82,6 +88,7 @@ public class HTMLScannerTest extends TestCase {
      * see issue https://sourceforge.net/tracker/?func=detail&atid=952178&aid=3544334&group_id=195122
      * @throws Exception
      */
+    @Test
     public void testLocale() throws Exception {
         final Locale originalLocale = Locale.getDefault();
         try {
@@ -105,6 +112,7 @@ public class HTMLScannerTest extends TestCase {
      * Following test caused NPE with release 1.9.11.
      * Regression test for [ 2503982 ] NPE when parsing from a CharacterStream
      */
+    @Test
     public void testChangeEncodingWithReader() throws Exception {
         String string = "<?xml version='1.0' encoding='UTF-8'?><html><head><title>foo</title></head>" + "</body></html>";
 
@@ -147,6 +155,7 @@ public class HTMLScannerTest extends TestCase {
 
     }
 
+    @Test
     public void testReduceToContent() throws Exception {
         XMLStringBuffer buffer = new XMLStringBuffer("<!-- hello-->");
 
@@ -174,6 +183,7 @@ public class HTMLScannerTest extends TestCase {
      * Regression test for bug 2933989.
      * @throws Exception
      */
+    @Test
     public void testInfiniteLoop() throws Exception {
         StringBuilder buffer = new StringBuilder();
         buffer.append("<html>\n");
@@ -211,6 +221,7 @@ public class HTMLScannerTest extends TestCase {
      * Regression test https://github.com/HtmlUnit/htmlunit-neko/pull/98.
      * @throws Exception on error
      */
+    @Test
     public void testReader() throws Exception {
         final String string = "<html><body>"//
                 + "<script type='text/javascript'>//<!-- /* <![CDATA[ */ function foo() {} /* ]]> */ // --> </script>"//

--- a/src/test/java/org/codelibs/nekohtml/HTMLTagBalancingListenerTest.java
+++ b/src/test/java/org/codelibs/nekohtml/HTMLTagBalancingListenerTest.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.parsers.AbstractSAXParser;
 import org.apache.xerces.xni.Augmentations;
@@ -36,8 +38,9 @@ import org.codelibs.nekohtml.HTMLTagBalancingListener;
  * @author Marc Guillemot
  * @version $Id$
  */
-public class HTMLTagBalancingListenerTest extends TestCase {
+public class HTMLTagBalancingListenerTest {
 
+    @Test
     public void testIgnoredTags() throws Exception {
         String string =
                 "<html><head><title>foo</title></head>" + "<body>" + "<body onload='alert(123)'>" + "<div>" + "<form action='foo'>"
@@ -60,6 +63,7 @@ public class HTMLTagBalancingListenerTest extends TestCase {
      * HTMLTagBalancer field fSeenFramesetElement was not correctly reset as of 1.19.17  
      * @throws Exception
      */
+    @Test
     public void testReuse() throws Exception {
         String string = "<head><title>title</title></head><body><div>hello</div></body>";
 

--- a/src/test/java/org/codelibs/nekohtml/HeadNamespaceBug.java
+++ b/src/test/java/org/codelibs/nekohtml/HeadNamespaceBug.java
@@ -17,7 +17,9 @@ package org.codelibs.nekohtml;
 
 import java.io.ByteArrayInputStream;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.parsers.AbstractSAXParser;
 import org.codelibs.nekohtml.HTMLConfiguration;
@@ -32,11 +34,12 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author Marc Guillemot
  *
  */
-public class HeadNamespaceBug extends TestCase {
+public class HeadNamespaceBug {
 
     /**
      * Ensure that the inserted head element has the right namespace
      */
+    @Test
     public void testHeadNamespace() throws Exception {
         final int[] nbTags = { 0 };
         final ContentHandler handler = new DefaultHandler() {

--- a/src/test/java/org/codelibs/nekohtml/LocatorEncodingTest.java
+++ b/src/test/java/org/codelibs/nekohtml/LocatorEncodingTest.java
@@ -19,7 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.impl.Version;
 import org.codelibs.nekohtml.parsers.SAXParser;
@@ -35,8 +37,9 @@ import org.xml.sax.ext.Locator2;
  * @author Marc Guillemot
  * @version $Revision$
  */
-public class LocatorEncodingTest extends TestCase {
+public class LocatorEncodingTest {
 
+    @Test
     public void test() throws SAXException, IOException {
         if (Version.getVersion().startsWith("Xerces-J 2.2") || Version.getVersion().startsWith("Xerces-J 2.3")) {
             return; // this test makes sense only for more recent Xerces versions

--- a/src/test/java/org/codelibs/nekohtml/filters/WriterTest.java
+++ b/src/test/java/org/codelibs/nekohtml/filters/WriterTest.java
@@ -19,7 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 import org.apache.xerces.xni.parser.XMLDocumentFilter;
 import org.apache.xerces.xni.parser.XMLInputSource;
@@ -32,12 +32,13 @@ import org.codelibs.nekohtml.filters.Writer;
  *
  * @author Marc Guillemot
  */
-public class WriterTest extends TestCase {
+public class WriterTest {
 
     /**
      * Regression test for bug: writer changed attribute value causing NPE in 2nd writer.
      * http://sourceforge.net/support/tracker.php?aid=2815779
      */
+    @Test
     public void testEmptyAttribute() throws Exception {
 
         final String content = "<html><head>" + "<meta name='COPYRIGHT' content='SOMEONE' />" + "</head><body></body></html>";


### PR DESCRIPTION
This PR introduces several major updates and improvements:

- Build & Workflow
  - Updated GitHub Actions workflow to use:
    - actions/checkout@v4 instead of v2
    - actions/setup-java@v4 with JDK 17 (temurin distribution) instead of JDK 11 (adopt)
  - Updated .gitignore to exclude /.serena
- Maven Configuration
  - Bumped project version from 2.1.4-SNAPSHOT → 3.0.0-SNAPSHOT
  - Updated Maven compiler plugin release version from 11 → 17
  - Replaced JUnit 4.13.2 with JUnit Jupiter 5.11.3
  - Added Mockito 5.14.2 (mockito-core and mockito-junit-jupiter) for testing
- Codebase Enhancements
  - Added detailed Javadoc comments across multiple classes:
    - HTMLAugmentations, HTMLConfiguration, HTMLElements, HTMLEntities, HTMLErrorReporter
    - HTMLEventInfo, HTMLScanner, HTMLTagBalancer, HTMLTagBalancingListener
    - DefaultFilter and related inner classes
  - Introduced default constructors with documentation where missing
  - Improved method documentation with parameter and return descriptions for better clarity and maintainability