### PR TITLE
feat(scanner): add HTML entity resolution in SimpleHTMLScanner

### DIFF
--- a/src/main/java/org/codelibs/nekohtml/sax/SimpleHTMLScanner.java
+++ b/src/main/java/org/codelibs/nekohtml/sax/SimpleHTMLScanner.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.codelibs.nekohtml.HTMLEntities;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;
@@ -353,11 +354,12 @@ public class SimpleHTMLScanner implements XMLReader {
                 // Text content
                 final int nextTag = html.indexOf('<', pos);
                 final int endPos = nextTag >= 0 ? nextTag : length;
-                final String text = html.substring(pos, endPos);
+                final String rawText = html.substring(pos, endPos);
 
                 // Always emit text content, including whitespace
                 // This preserves spacing between elements for proper text extraction
-                if (text.length() > 0) {
+                if (rawText.length() > 0) {
+                    final String text = resolveEntities(rawText);
                     fContentHandler.characters(text.toCharArray(), 0, text.length());
                 }
 
@@ -398,7 +400,7 @@ public class SimpleHTMLScanner implements XMLReader {
                 value = ""; // No value
             }
 
-            attrs.addAttribute("", name, name, "CDATA", value);
+            attrs.addAttribute("", name, name, "CDATA", resolveEntities(value, true));
         }
 
         return attrs;
@@ -434,6 +436,125 @@ public class SimpleHTMLScanner implements XMLReader {
             return name;
         }
         return "upper".equals(fAttributeCase) ? name.toUpperCase() : "lower".equals(fAttributeCase) ? name.toLowerCase() : name;
+    }
+
+    // Pattern for HTML character references: &#decimal; or &#xhex; or &name;
+    // Semicolon is optional to handle common malformed HTML
+    private static final Pattern ENTITY_PATTERN = Pattern.compile("&(?:#([0-9]+)|#[xX]([0-9a-fA-F]+)|([a-zA-Z][a-zA-Z0-9]*));?");
+
+    /**
+     * Resolves HTML character entities in text content.
+     * Semicolon-less named entities are decoded in text context.
+     *
+     * @param text The text containing entities
+     * @return The text with entities resolved to their character equivalents
+     */
+    protected String resolveEntities(final String text) {
+        return resolveEntities(text, false);
+    }
+
+    /**
+     * Resolves HTML character entities in the given text.
+     * Handles numeric decimal (&#214;), numeric hex (&#xD6;), and named (&Ouml;) entities.
+     * In attribute context, semicolon-less named entities followed by [A-Za-z0-9=] are not decoded
+     * per HTML5 attribute value state rules, preventing corruption of URLs like &not=, &copy=.
+     *
+     * @param text The text containing entities
+     * @param inAttribute Whether this text is an attribute value
+     * @return The text with entities resolved to their character equivalents
+     */
+    protected String resolveEntities(final String text, final boolean inAttribute) {
+        if (text == null || text.indexOf('&') < 0) {
+            return text;
+        }
+
+        final Matcher m = ENTITY_PATTERN.matcher(text);
+        final StringBuilder sb = new StringBuilder(text.length());
+        int lastEnd = 0;
+
+        while (m.find()) {
+            sb.append(text, lastEnd, m.start());
+
+            if (m.group(1) != null) {
+                // Numeric decimal: &#214;
+                try {
+                    final int codePoint = Integer.parseInt(m.group(1));
+                    sb.append(resolveCodePoint(codePoint, m.group(0)));
+                } catch (final NumberFormatException e) {
+                    sb.append(m.group(0));
+                }
+            } else if (m.group(2) != null) {
+                // Numeric hex: &#xD6;
+                try {
+                    final int codePoint = Integer.parseInt(m.group(2), 16);
+                    sb.append(resolveCodePoint(codePoint, m.group(0)));
+                } catch (final NumberFormatException e) {
+                    sb.append(m.group(0));
+                }
+            } else if (m.group(3) != null) {
+                // Named entity: &Ouml;
+                final String matched = m.group(0);
+                final boolean hasSemicolon = matched.endsWith(";");
+
+                // HTML5 attribute value state: if no semicolon and next char is [A-Za-z0-9=],
+                // do not decode (prevents corruption of URLs like &not=2, &copy=, &reg=)
+                if (inAttribute && !hasSemicolon) {
+                    final int afterEnd = m.end();
+                    if (afterEnd < text.length()) {
+                        final char nextChar = text.charAt(afterEnd);
+                        if (Character.isLetterOrDigit(nextChar) || nextChar == '=') {
+                            sb.append(matched);
+                            lastEnd = m.end();
+                            continue;
+                        }
+                    }
+                }
+
+                final int c = HTMLEntities.get(m.group(3));
+                if (c != -1) {
+                    sb.appendCodePoint(c);
+                } else {
+                    sb.append(matched);
+                }
+            }
+
+            lastEnd = m.end();
+        }
+
+        sb.append(text, lastEnd, text.length());
+        return sb.toString();
+    }
+
+    /**
+     * Validates a numeric code point and returns the resolved character or replacement.
+     * Invalid code points (null char, surrogates, out of range, XML-illegal) are replaced with U+FFFD.
+     */
+    private static String resolveCodePoint(final int codePoint, final String original) {
+        if (codePoint == 0) {
+            // Null character: replace with U+FFFD per HTML5 spec
+            return "\uFFFD";
+        }
+        if (codePoint >= 0xD800 && codePoint <= 0xDFFF) {
+            // Surrogate range: invalid Unicode scalar value
+            return "\uFFFD";
+        }
+        if (codePoint > 0x10FFFF) {
+            // Out of Unicode range
+            return "\uFFFD";
+        }
+        // XML 1.0 illegal characters (except tab, newline, carriage return)
+        if (codePoint < 0x20 && codePoint != 0x9 && codePoint != 0xA && codePoint != 0xD) {
+            return "\uFFFD";
+        }
+        if (codePoint >= 0xFDD0 && codePoint <= 0xFDEF) {
+            // Unicode noncharacters
+            return "\uFFFD";
+        }
+        if ((codePoint & 0xFFFE) == 0xFFFE) {
+            // U+xFFFE and U+xFFFF are noncharacters
+            return "\uFFFD";
+        }
+        return new String(Character.toChars(codePoint));
     }
 
     @Override

--- a/src/test/java/org/codelibs/nekohtml/EncodingEdgeCasesTest.java
+++ b/src/test/java/org/codelibs/nekohtml/EncodingEdgeCasesTest.java
@@ -125,11 +125,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testZeroWidthCharacters() throws Exception {
         // Given: HTML with zero-width characters
-        final String html = "<html><body>"
-                + "Zero\u200BWidth\u200BSpace "
-                + "Zero\u200CWidth\u200CNon\u200CJoiner "
-                + "Zero\u200DWidth\u200DJoiner"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "Zero\u200BWidth\u200BSpace " + "Zero\u200CWidth\u200CNon\u200CJoiner " + "Zero\u200DWidth\u200DJoiner"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -145,10 +143,8 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testRightToLeftMarks() throws Exception {
         // Given: HTML with RTL and LTR marks
-        final String html = "<html><body>"
-                + "Text\u200Ewith\u200ELTR\u200Emarks "
-                + "Text\u200Fwith\u200FRTL\u200Fmarks"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "Text\u200Ewith\u200ELTR\u200Emarks " + "Text\u200Fwith\u200FRTL\u200Fmarks" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -163,8 +159,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testCombiningCharacters() throws Exception {
         // Given: HTML with combining diacritics
-        final String html = "<html><body>"
-                + "e\u0301 " // é (e + combining acute)
+        final String html = "<html><body>" + "e\u0301 " // é (e + combining acute)
                 + "n\u0303 " // ñ (n + combining tilde)
                 + "a\u0308 " // ä (a + combining diaeresis)
                 + "</body></html>";
@@ -183,11 +178,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testEmojiAndSupplementaryCharacters() throws Exception {
         // Given: HTML with emoji (supplementary characters)
-        final String html = "<html><body>"
-                + "😀😁😂🤣😃😄😅😆😉😊 "
-                + "👍👎👏🙌🎉🎊🎈 "
-                + "🌟⭐✨💫"
-                + "</body></html>";
+        final String html = "<html><body>" + "😀😁😂🤣😃😄😅😆😉😊 " + "👍👎👏🙌🎉🎊🎈 " + "🌟⭐✨💫" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -203,8 +194,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testSurrogatePairs() throws Exception {
         // Given: HTML with characters requiring surrogate pairs
-        final String html = "<html><body>"
-                + "\uD834\uDD1E" // Musical symbol G clef (U+1D11E)
+        final String html = "<html><body>" + "\uD834\uDD1E" // Musical symbol G clef (U+1D11E)
                 + "\uD835\uDC00" // Mathematical bold capital A (U+1D400)
                 + "\uD83D\uDE00" // Grinning face emoji (U+1F600)
                 + "</body></html>";
@@ -221,9 +211,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testControlCharacters() throws Exception {
         // Given: HTML with control characters (allowed ones)
-        final String html = "<html><body>"
-                + "Tab:\t Newline:\n CarriageReturn:\r"
-                + "</body></html>";
+        final String html = "<html><body>" + "Tab:\t Newline:\n CarriageReturn:\r" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -237,15 +225,10 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMultilingualContent() throws Exception {
         // Given: HTML with multiple languages
-        final String html = "<html><body>"
-                + "<p lang=\"ja\">日本語のテキスト</p>"
-                + "<p lang=\"zh\">中文文本</p>"
-                + "<p lang=\"ko\">한국어 텍스트</p>"
-                + "<p lang=\"ar\">نص عربي</p>"
-                + "<p lang=\"ru\">Русский текст</p>"
-                + "<p lang=\"el\">Ελληνικό κείμενο</p>"
-                + "<p lang=\"he\">טקסט עברי</p>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<p lang=\"ja\">日本語のテキスト</p>" + "<p lang=\"zh\">中文文本</p>" + "<p lang=\"ko\">한국어 텍스트</p>"
+                        + "<p lang=\"ar\">نص عربي</p>" + "<p lang=\"ru\">Русский текст</p>" + "<p lang=\"el\">Ελληνικό κείμενο</p>"
+                        + "<p lang=\"he\">טקסט עברי</p>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -275,10 +258,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMalformedEntities() throws Exception {
         // Given: HTML with malformed entities
-        final String html = "<html><body>"
-                + "&invalid; "
-                + "&notanentity; "
-                + "&lt " // missing semicolon
+        final String html = "<html><body>" + "&invalid; " + "&notanentity; " + "&lt " // missing semicolon
                 + "&gt " // missing semicolon
                 + "&amp" // missing semicolon
                 + "</body></html>";
@@ -295,8 +275,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testNumericEntitiesOutOfRange() throws Exception {
         // Given: HTML with out-of-range numeric entities
-        final String html = "<html><body>"
-                + "&#xFFFFFFFF; " // way out of range
+        final String html = "<html><body>" + "&#xFFFFFFFF; " // way out of range
                 + "&#999999999; " // huge decimal
                 + "&#x110000; " // just beyond Unicode range
                 + "</body></html>";
@@ -325,11 +304,10 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testEntitiesInAttributeValues() throws Exception {
         // Given: HTML with entities in attribute values
-        final String html = "<html><body>"
-                + "<div title=\"&lt;Click &amp; drag&gt;\">Content</div>"
-                + "<a href=\"?param1=value1&amp;param2=value2\">Link</a>"
-                + "<input value=\"&quot;Quoted&quot;\">"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<div title=\"&lt;Click &amp; drag&gt;\">Content</div>"
+                        + "<a href=\"?param1=value1&amp;param2=value2\">Link</a>" + "<input value=\"&quot;Quoted&quot;\">"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -355,15 +333,10 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testAllCommonHTMLEntities() throws Exception {
         // Given: HTML with all common entities
-        final String html = "<html><body>"
-                + "&nbsp; &lt; &gt; &amp; &quot; &apos; "
-                + "&copy; &reg; &trade; "
-                + "&euro; &pound; &yen; &cent; "
-                + "&mdash; &ndash; &hellip; "
-                + "&laquo; &raquo; &ldquo; &rdquo; &lsquo; &rsquo; "
-                + "&deg; &plusmn; &times; &divide; "
-                + "&para; &sect; &dagger; &Dagger; "
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "&nbsp; &lt; &gt; &amp; &quot; &apos; " + "&copy; &reg; &trade; " + "&euro; &pound; &yen; &cent; "
+                        + "&mdash; &ndash; &hellip; " + "&laquo; &raquo; &ldquo; &rdquo; &lsquo; &rsquo; "
+                        + "&deg; &plusmn; &times; &divide; " + "&para; &sect; &dagger; &Dagger; " + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -381,8 +354,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testNumericCharacterReferences() throws Exception {
         // Given: HTML with numeric character references
-        final String html = "<html><body>"
-                + "&#65; " // A
+        final String html = "<html><body>" + "&#65; " // A
                 + "&#x41; " // A (hex)
                 + "&#169; " // ©
                 + "&#x00A9; " // © (hex)
@@ -405,9 +377,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testEntitiesWithoutSemicolon() throws Exception {
         // Given: HTML with entities without semicolons (legacy)
-        final String html = "<html><body>"
-                + "&lt &gt &amp &copy &reg"
-                + "</body></html>";
+        final String html = "<html><body>" + "&lt &gt &amp &copy &reg" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -424,11 +394,10 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMultipleMetaCharsetDeclarations() throws Exception {
         // Given: HTML with multiple conflicting charset declarations
-        final String html = "<html><head>"
-                + "<meta charset=\"ISO-8859-1\">"
-                + "<meta charset=\"UTF-8\">"
-                + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Windows-1252\">"
-                + "</head><body>Content</body></html>";
+        final String html =
+                "<html><head>" + "<meta charset=\"ISO-8859-1\">" + "<meta charset=\"UTF-8\">"
+                        + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Windows-1252\">"
+                        + "</head><body>Content</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -442,11 +411,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMetaCharsetVariations() throws Exception {
         // Given: HTML with various meta charset formats
-        final String html = "<html><head>"
-                + "<meta charset=\"utf-8\">"
-                + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">"
-                + "<meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">"
-                + "</head><body>Test</body></html>";
+        final String html =
+                "<html><head>" + "<meta charset=\"utf-8\">" + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">"
+                        + "<meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">" + "</head><body>Test</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -460,8 +427,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testXMLDeclarationVsMetaCharset() throws Exception {
         // Given: HTML with both XML declaration and meta charset
-        final String html = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
-                + "<html><head><meta charset=\"UTF-8\"></head><body>Content</body></html>";
+        final String html =
+                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
+                        + "<html><head><meta charset=\"UTF-8\"></head><body>Content</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -478,14 +446,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testNonBreakingSpaces() throws Exception {
         // Given: HTML with various types of spaces
-        final String html = "<html><body>"
-                + "Regular space "
-                + "Non-breaking&nbsp;space "
-                + "En\u2002space "
-                + "Em\u2003space "
-                + "Thin\u2009space "
-                + "Hair\u200Aspace"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "Regular space " + "Non-breaking&nbsp;space " + "En\u2002space " + "Em\u2003space " + "Thin\u2009space "
+                        + "Hair\u200Aspace" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -504,12 +467,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testSpecialPunctuationCharacters() throws Exception {
         // Given: HTML with special punctuation
-        final String html = "<html><body>"
-                + "Quotes: \u201C\u201D \u2018\u2019 "
-                + "Dashes: \u2013 \u2014 "
-                + "Ellipsis: \u2026 "
-                + "Bullet: \u2022 "
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "Quotes: \u201C\u201D \u2018\u2019 " + "Dashes: \u2013 \u2014 " + "Ellipsis: \u2026 " + "Bullet: \u2022 "
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -526,9 +486,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMathematicalSymbols() throws Exception {
         // Given: HTML with mathematical symbols
-        final String html = "<html><body>"
-                + "∞ ≠ ≤ ≥ ± × ÷ √ ∑ ∏ ∫ ∂ ∇"
-                + "</body></html>";
+        final String html = "<html><body>" + "∞ ≠ ≤ ≥ ± × ÷ √ ∑ ∏ ∫ ∂ ∇" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -544,9 +502,7 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testCurrencySymbols() throws Exception {
         // Given: HTML with various currency symbols
-        final String html = "<html><body>"
-                + "$ € £ ¥ ₹ ₽ ₩ ¢ ฿"
-                + "</body></html>";
+        final String html = "<html><body>" + "$ € £ ¥ ₹ ₽ ₩ ¢ ฿" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -562,11 +518,9 @@ public class EncodingEdgeCasesTest {
     @Test
     public void testMixedDirectionalText() throws Exception {
         // Given: HTML with mixed LTR and RTL text
-        final String html = "<html><body>"
-                + "<p dir=\"ltr\">Left-to-right text with עברית embedded</p>"
-                + "<p dir=\"rtl\">טקסט מימין לשמאל with English embedded</p>"
-                + "<p>Mixed: Hello שלום مرحبا</p>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<p dir=\"ltr\">Left-to-right text with עברית embedded</p>"
+                        + "<p dir=\"rtl\">טקסט מימין לשמאל with English embedded</p>" + "<p>Mixed: Hello שלום مرحبا</p>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/HTML5SemanticElementsIntegrationTest.java
+++ b/src/test/java/org/codelibs/nekohtml/HTML5SemanticElementsIntegrationTest.java
@@ -91,7 +91,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSearchElementInAside() throws Exception {
         // Given: HTML with SEARCH in ASIDE (common pattern for sidebar search)
-        final String html = "<html><body><main>Main content</main><aside><search><form><label>Filter:<input type=\"search\"></label></form></search></aside></body></html>";
+        final String html =
+                "<html><body><main>Main content</main><aside><search><form><label>Filter:<input type=\"search\"></label></form></search></aside></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -108,10 +109,10 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testMultipleSearchElements() throws Exception {
         // Given: HTML with multiple SEARCH elements
-        final String html = "<html><body>"
-                + "<header><search><input type=\"search\" placeholder=\"Global search\"></search></header>"
-                + "<main><article><search><input type=\"search\" placeholder=\"Article search\"></search></article></main>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<header><search><input type=\"search\" placeholder=\"Global search\"></search></header>"
+                        + "<main><article><search><input type=\"search\" placeholder=\"Article search\"></search></article></main>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -124,14 +125,10 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSearchWithAutocompleteAndDatalist() throws Exception {
         // Given: HTML with SEARCH containing autocomplete and datalist
-        final String html = "<html><body><search>"
-                + "<input type=\"search\" list=\"suggestions\" autocomplete=\"on\">"
-                + "<datalist id=\"suggestions\">"
-                + "<option value=\"Apple\">"
-                + "<option value=\"Banana\">"
-                + "<option value=\"Cherry\">"
-                + "</datalist>"
-                + "</search></body></html>";
+        final String html =
+                "<html><body><search>" + "<input type=\"search\" list=\"suggestions\" autocomplete=\"on\">"
+                        + "<datalist id=\"suggestions\">" + "<option value=\"Apple\">" + "<option value=\"Banana\">"
+                        + "<option value=\"Cherry\">" + "</datalist>" + "</search></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -155,11 +152,9 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSearchClosingWithAdjacentBlockElements() throws Exception {
         // Given: HTML with SEARCH followed by other block elements
-        final String html = "<html><body>"
-                + "<search><input type=\"search\"></search>"
-                + "<nav><ul><li>Link 1</li></ul></nav>"
-                + "<article>Content</article>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<search><input type=\"search\"></search>" + "<nav><ul><li>Link 1</li></ul></nav>"
+                        + "<article>Content</article>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -239,11 +234,10 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testMultipleSlotsInTemplate() throws Exception {
         // Given: HTML with multiple SLOTs in TEMPLATE
-        final String html = "<html><body><template id=\"my-template\">"
-                + "<header><slot name=\"header\">Default Header</slot></header>"
-                + "<main><slot>Default Content</slot></main>"
-                + "<footer><slot name=\"footer\">Default Footer</slot></footer>"
-                + "</template></body></html>";
+        final String html =
+                "<html><body><template id=\"my-template\">" + "<header><slot name=\"header\">Default Header</slot></header>"
+                        + "<main><slot>Default Content</slot></main>" + "<footer><slot name=\"footer\">Default Footer</slot></footer>"
+                        + "</template></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -265,7 +259,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testNestedSlotElements() throws Exception {
         // Given: HTML with nested SLOTs (edge case)
-        final String html = "<html><body><template><div><slot name=\"outer\"><div><slot name=\"inner\">Fallback</slot></div></slot></div></template></body></html>";
+        final String html =
+                "<html><body><template><div><slot name=\"outer\"><div><slot name=\"inner\">Fallback</slot></div></slot></div></template></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -302,14 +297,9 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testHgroupWithAllHeadingLevels() throws Exception {
         // Given: HTML with HGROUP containing H1-H6
-        final String html = "<html><body><hgroup>"
-                + "<h1>Level 1</h1>"
-                + "<h2>Level 2</h2>"
-                + "<h3>Level 3</h3>"
-                + "<h4>Level 4</h4>"
-                + "<h5>Level 5</h5>"
-                + "<h6>Level 6</h6>"
-                + "</hgroup></body></html>";
+        final String html =
+                "<html><body><hgroup>" + "<h1>Level 1</h1>" + "<h2>Level 2</h2>" + "<h3>Level 3</h3>" + "<h4>Level 4</h4>"
+                        + "<h5>Level 5</h5>" + "<h6>Level 6</h6>" + "</hgroup></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -362,7 +352,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testHgroupInArticle() throws Exception {
         // Given: HTML with HGROUP in ARTICLE
-        final String html = "<html><body><article><hgroup><h1>Article Title</h1><h2>Author Name</h2></hgroup><p>Article content</p></article></body></html>";
+        final String html =
+                "<html><body><article><hgroup><h1>Article Title</h1><h2>Author Name</h2></hgroup><p>Article content</p></article></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -379,7 +370,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testHgroupInSection() throws Exception {
         // Given: HTML with HGROUP in SECTION
-        final String html = "<html><body><section><hgroup><h2>Section Title</h2><h3>Section Subtitle</h3></hgroup><p>Content</p></section></body></html>";
+        final String html =
+                "<html><body><section><hgroup><h2>Section Title</h2><h3>Section Subtitle</h3></hgroup><p>Content</p></section></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -396,10 +388,10 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testMultipleHgroups() throws Exception {
         // Given: HTML with multiple HGROUPs
-        final String html = "<html><body>"
-                + "<article><hgroup><h1>First Article</h1><h2>First Subtitle</h2></hgroup><p>Content 1</p></article>"
-                + "<article><hgroup><h1>Second Article</h1><h2>Second Subtitle</h2></hgroup><p>Content 2</p></article>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<article><hgroup><h1>First Article</h1><h2>First Subtitle</h2></hgroup><p>Content 1</p></article>"
+                        + "<article><hgroup><h1>Second Article</h1><h2>Second Subtitle</h2></hgroup><p>Content 2</p></article>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -437,25 +429,13 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testComplexSemanticStructureWithNewElements() throws Exception {
         // Given: Complex HTML using SEARCH, SLOT, HGROUP together
-        final String html = "<html><body>"
-                + "<header>"
-                + "<hgroup><h1>Website Title</h1><h2>Tagline</h2></hgroup>"
-                + "<search><input type=\"search\" placeholder=\"Search site...\"></search>"
-                + "</header>"
-                + "<main>"
-                + "<article>"
-                + "<hgroup><h2>Article Title</h2><h3>Article Subtitle</h3></hgroup>"
-                + "<p>Article content here</p>"
-                + "</article>"
-                + "<aside>"
-                + "<search><form><input type=\"search\" placeholder=\"Filter...\"></form></search>"
-                + "</aside>"
-                + "</main>"
-                + "<template id=\"card\">"
-                + "<slot name=\"title\"><h3>Default Title</h3></slot>"
-                + "<slot name=\"content\"><p>Default content</p></slot>"
-                + "</template>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<header>" + "<hgroup><h1>Website Title</h1><h2>Tagline</h2></hgroup>"
+                        + "<search><input type=\"search\" placeholder=\"Search site...\"></search>" + "</header>" + "<main>" + "<article>"
+                        + "<hgroup><h2>Article Title</h2><h3>Article Subtitle</h3></hgroup>" + "<p>Article content here</p>" + "</article>"
+                        + "<aside>" + "<search><form><input type=\"search\" placeholder=\"Filter...\"></form></search>" + "</aside>"
+                        + "</main>" + "<template id=\"card\">" + "<slot name=\"title\"><h3>Default Title</h3></slot>"
+                        + "<slot name=\"content\"><p>Default content</p></slot>" + "</template>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -477,7 +457,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSearchInMain() throws Exception {
         // Given: SEARCH in MAIN element
-        final String html = "<html><body><main><search><form action=\"/search\"><input type=\"search\" name=\"q\"></form></search></main></body></html>";
+        final String html =
+                "<html><body><main><search><form action=\"/search\"><input type=\"search\" name=\"q\"></form></search></main></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -494,7 +475,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testHgroupInFooter() throws Exception {
         // Given: HGROUP in FOOTER (less common but valid)
-        final String html = "<html><body><footer><hgroup><h2>Footer Section</h2><h3>Additional Info</h3></hgroup><p>Footer content</p></footer></body></html>";
+        final String html =
+                "<html><body><footer><hgroup><h2>Footer Section</h2><h3>Additional Info</h3></hgroup><p>Footer content</p></footer></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -511,15 +493,12 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSearchWithComplexFormElements() throws Exception {
         // Given: SEARCH with complex form containing multiple inputs
-        final String html = "<html><body><search><form>"
-                + "<fieldset>"
-                + "<legend>Advanced Search</legend>"
-                + "<label>Keyword: <input type=\"search\" name=\"keyword\"></label>"
-                + "<label>Category: <select name=\"category\"><option>All</option><option>News</option></select></label>"
-                + "<label>Date: <input type=\"date\" name=\"date\"></label>"
-                + "<button type=\"submit\">Search</button>"
-                + "</fieldset>"
-                + "</form></search></body></html>";
+        final String html =
+                "<html><body><search><form>" + "<fieldset>" + "<legend>Advanced Search</legend>"
+                        + "<label>Keyword: <input type=\"search\" name=\"keyword\"></label>"
+                        + "<label>Category: <select name=\"category\"><option>All</option><option>News</option></select></label>"
+                        + "<label>Date: <input type=\"date\" name=\"date\"></label>" + "<button type=\"submit\">Search</button>"
+                        + "</fieldset>" + "</form></search></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -539,7 +518,8 @@ public class HTML5SemanticElementsIntegrationTest {
     @Test
     public void testSlotInCustomElement() throws Exception {
         // Given: SLOT in custom element context
-        final String html = "<html><body><template><custom-card><slot name=\"header\"></slot><slot></slot><slot name=\"footer\"></slot></custom-card></template></body></html>";
+        final String html =
+                "<html><body><template><custom-card><slot name=\"header\"></slot><slot></slot><slot name=\"footer\"></slot></custom-card></template></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/PerformanceStressTest.java
+++ b/src/test/java/org/codelibs/nekohtml/PerformanceStressTest.java
@@ -439,15 +439,10 @@ public class PerformanceStressTest {
         // Given: Complex realistic document structure
         final StringBuilder html = new StringBuilder("<html><head><title>Test</title></head><body>");
         for (int i = 0; i < 100; i++) {
-            html.append("<article>")
-                    .append("<header><h1>Title ").append(i).append("</h1></header>")
-                    .append("<section>")
-                    .append("<p>Paragraph 1</p>")
-                    .append("<p>Paragraph 2</p>")
-                    .append("<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>")
-                    .append("</section>")
-                    .append("<footer><p>Footer</p></footer>")
-                    .append("</article>");
+            html.append("<article>").append("<header><h1>Title ").append(i).append("</h1></header>").append("<section>")
+                    .append("<p>Paragraph 1</p>").append("<p>Paragraph 2</p>")
+                    .append("<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>").append("</section>")
+                    .append("<footer><p>Footer</p></footer>").append("</article>");
         }
         html.append("</body></html>");
 

--- a/src/test/java/org/codelibs/nekohtml/ThreadSafetyTest.java
+++ b/src/test/java/org/codelibs/nekohtml/ThreadSafetyTest.java
@@ -44,11 +44,8 @@ import org.xml.sax.helpers.DefaultHandler;
 public class ThreadSafetyTest {
 
     private static final String SIMPLE_HTML = "<html><body><div>Content</div></body></html>";
-    private static final String COMPLEX_HTML = "<html><head><title>Test</title></head><body>"
-            + "<article><header><h1>Title</h1></header>"
-            + "<section><p>Paragraph 1</p><p>Paragraph 2</p></section>"
-            + "<footer>Footer</footer></article>"
-            + "</body></html>";
+    private static final String COMPLEX_HTML = "<html><head><title>Test</title></head><body>" + "<article><header><h1>Title</h1></header>"
+            + "<section><p>Paragraph 1</p><p>Paragraph 2</p></section>" + "<footer>Footer</footer></article>" + "</body></html>";
 
     // ========================================================================
     // Concurrent Parsing with Separate Parser Instances
@@ -104,8 +101,8 @@ public class ThreadSafetyTest {
                 public Boolean call() throws Exception {
                     try {
                         final DOMParser parser = new DOMParser();
-                        final String html = "<html><body><h1>Thread " + threadId + "</h1>"
-                                + "<p>Paragraph " + threadId + "</p></body></html>";
+                        final String html =
+                                "<html><body><h1>Thread " + threadId + "</h1>" + "<p>Paragraph " + threadId + "</p></body></html>";
                         parser.parse(new InputSource(new StringReader(html)));
                         final Document doc = parser.getDocument();
 
@@ -137,10 +134,10 @@ public class ThreadSafetyTest {
         final ExecutorService executor = Executors.newFixedThreadPool(10);
         final List<Future<Boolean>> futures = new ArrayList<>();
 
-        final String[] htmlTypes = new String[] { SIMPLE_HTML, COMPLEX_HTML,
-                "<html><body><table><tr><td>Table</td></tr></table></body></html>",
-                "<html><body><form><input type=\"text\"></form></body></html>",
-                "<html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>" };
+        final String[] htmlTypes =
+                new String[] { SIMPLE_HTML, COMPLEX_HTML, "<html><body><table><tr><td>Table</td></tr></table></body></html>",
+                        "<html><body><form><input type=\"text\"></form></body></html>",
+                        "<html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>" };
 
         // When: Threads parse different document types
         for (int i = 0; i < threadCount; i++) {
@@ -311,9 +308,10 @@ public class ThreadSafetyTest {
         final AtomicInteger successCount = new AtomicInteger(0);
         final List<Future<Boolean>> futures = new ArrayList<>();
 
-        final String[] malformedHTML = new String[] { "<html><body><div>Unclosed div", "<html><body><b><i></b></i></body></html>",
-                "<html><body><table><td>No TR</td></table></body></html>", "<html><body><p>Paragraph <div>Block</div> continues</p>",
-                "<html><body><ul><div>Wrong nesting</div></ul>" };
+        final String[] malformedHTML =
+                new String[] { "<html><body><div>Unclosed div", "<html><body><b><i></b></i></body></html>",
+                        "<html><body><table><td>No TR</td></table></body></html>",
+                        "<html><body><p>Paragraph <div>Block</div> continues</p>", "<html><body><ul><div>Wrong nesting</div></ul>" };
 
         // When: Threads parse malformed HTML
         for (int i = 0; i < threadCount; i++) {

--- a/src/test/java/org/codelibs/nekohtml/parsers/AttributeEdgeCasesTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/AttributeEdgeCasesTest.java
@@ -89,7 +89,8 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testAttributesWithColons() throws Exception {
         // Given: Attributes with colons (namespace-like)
-        final String html = "<html><body><div xml:lang=\"en\" xlink:href=\"#\" xmlns:custom=\"http://example.com\">Content</div></body></html>";
+        final String html =
+                "<html><body><div xml:lang=\"en\" xlink:href=\"#\" xmlns:custom=\"http://example.com\">Content</div></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -317,13 +318,9 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testBooleanAttributesWithoutValues() throws Exception {
         // Given: Boolean attributes without values
-        final String html = "<html><body>"
-                + "<input type=\"checkbox\" checked>"
-                + "<input type=\"text\" disabled>"
-                + "<input type=\"text\" readonly>"
-                + "<button autofocus>Button</button>"
-                + "<script async></script>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<input type=\"checkbox\" checked>" + "<input type=\"text\" disabled>" + "<input type=\"text\" readonly>"
+                        + "<button autofocus>Button</button>" + "<script async></script>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -337,12 +334,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testBooleanAttributesWithValues() throws Exception {
         // Given: Boolean attributes with values (valid in HTML)
-        final String html = "<html><body>"
-                + "<input type=\"checkbox\" checked=\"checked\">"
-                + "<input type=\"text\" disabled=\"disabled\">"
-                + "<input type=\"text\" readonly=\"readonly\">"
-                + "<option selected=\"selected\">Option</option>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<input type=\"checkbox\" checked=\"checked\">" + "<input type=\"text\" disabled=\"disabled\">"
+                        + "<input type=\"text\" readonly=\"readonly\">" + "<option selected=\"selected\">Option</option>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -356,11 +351,9 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testBooleanAttributesWithInvalidValues() throws Exception {
         // Given: Boolean attributes with invalid values
-        final String html = "<html><body>"
-                + "<input type=\"checkbox\" checked=\"false\">"
-                + "<input type=\"text\" disabled=\"no\">"
-                + "<input type=\"text\" readonly=\"0\">"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<input type=\"checkbox\" checked=\"false\">" + "<input type=\"text\" disabled=\"no\">"
+                        + "<input type=\"text\" readonly=\"0\">" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -374,18 +367,11 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testAllBooleanHTMLAttributes() throws Exception {
         // Given: All common boolean HTML attributes
-        final String html = "<html><body>"
-                + "<input checked disabled readonly required autofocus>"
-                + "<button formnovalidate>Button</button>"
-                + "<video autoplay controls loop muted>Video</video>"
-                + "<ol reversed>List</ol>"
-                + "<details open>Details</details>"
-                + "<script async defer></script>"
-                + "<iframe seamless></iframe>"
-                + "<track default>"
-                + "<option selected>Option</option>"
-                + "<optgroup disabled>Group</optgroup>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<input checked disabled readonly required autofocus>" + "<button formnovalidate>Button</button>"
+                        + "<video autoplay controls loop muted>Video</video>" + "<ol reversed>List</ol>"
+                        + "<details open>Details</details>" + "<script async defer></script>" + "<iframe seamless></iframe>"
+                        + "<track default>" + "<option selected>Option</option>" + "<optgroup disabled>Group</optgroup>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -434,11 +420,8 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testAttributesWithNewlinesBetweenThem() throws Exception {
         // Given: Attributes on multiple lines
-        final String html = "<html><body><div\n"
-                + "id=\"test\"\n"
-                + "class=\"myclass\"\n"
-                + "title=\"title\"\n"
-                + ">Content</div></body></html>";
+        final String html =
+                "<html><body><div\n" + "id=\"test\"\n" + "class=\"myclass\"\n" + "title=\"title\"\n" + ">Content</div></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -474,9 +457,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testDataAttributes() throws Exception {
         // Given: Various data attributes
-        final String html = "<html><body>"
-                + "<div data-id=\"123\" data-user-name=\"John Doe\" data-timestamp=\"2025-01-01\" data-json='{\"key\":\"value\"}'>Content</div>"
-                + "</body></html>";
+        final String html =
+                "<html><body>"
+                        + "<div data-id=\"123\" data-user-name=\"John Doe\" data-timestamp=\"2025-01-01\" data-json='{\"key\":\"value\"}'>Content</div>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -493,9 +477,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testAriaAttributes() throws Exception {
         // Given: ARIA attributes
-        final String html = "<html><body>"
-                + "<div role=\"button\" aria-label=\"Close\" aria-hidden=\"false\" aria-expanded=\"true\" aria-controls=\"menu\">Button</div>"
-                + "</body></html>";
+        final String html =
+                "<html><body>"
+                        + "<div role=\"button\" aria-label=\"Close\" aria-hidden=\"false\" aria-expanded=\"true\" aria-controls=\"menu\">Button</div>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -512,9 +497,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testEventHandlerAttributes() throws Exception {
         // Given: Event handler attributes
-        final String html = "<html><body>"
-                + "<button onclick=\"alert('clicked')\" onmouseover=\"highlight()\" onmouseout=\"unhighlight()\">Button</button>"
-                + "</body></html>";
+        final String html =
+                "<html><body>"
+                        + "<button onclick=\"alert('clicked')\" onmouseover=\"highlight()\" onmouseout=\"unhighlight()\">Button</button>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -530,9 +516,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testStyleAttribute() throws Exception {
         // Given: Style attribute with complex CSS
-        final String html = "<html><body>"
-                + "<div style=\"color: red; background-color: blue; margin: 10px; padding: 5px 10px; font-size: 14px;\">Content</div>"
-                + "</body></html>";
+        final String html =
+                "<html><body>"
+                        + "<div style=\"color: red; background-color: blue; margin: 10px; padding: 5px 10px; font-size: 14px;\">Content</div>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -565,11 +552,10 @@ public class AttributeEdgeCasesTest {
     @Test
     public void testAttributeWithURL() throws Exception {
         // Given: Attributes with URLs
-        final String html = "<html><body>"
-                + "<a href=\"https://example.com/path?param1=value1&param2=value2#anchor\">Link</a>"
-                + "<img src=\"/images/photo.jpg\" alt=\"Photo\">"
-                + "<link rel=\"stylesheet\" href=\"/css/styles.css\">"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<a href=\"https://example.com/path?param1=value1&param2=value2#anchor\">Link</a>"
+                        + "<img src=\"/images/photo.jpg\" alt=\"Photo\">" + "<link rel=\"stylesheet\" href=\"/css/styles.css\">"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrowserQuirksIntegrationTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrowserQuirksIntegrationTest.java
@@ -123,8 +123,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testTableWithMissingCloseTags() throws Exception {
         // Given: Table with missing close tags (common in legacy HTML)
-        final String html = "<html><body><table>" + "<tr><td>Row 1, Cell 1<td>Row 1, Cell 2" + "<tr><td>Row 2, Cell 1<td>Row 2, Cell 2"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Row 1, Cell 1<td>Row 1, Cell 2" + "<tr><td>Row 2, Cell 1<td>Row 2, Cell 2"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -138,8 +139,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testNestedTables() throws Exception {
         // Given: Nested tables
-        final String html = "<html><body>" + "<table><tr><td>" + "<table><tr><td>Inner cell</td></tr></table>" + "</td></tr></table>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<table><tr><td>" + "<table><tr><td>Inner cell</td></tr></table>" + "</td></tr></table>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -151,7 +153,8 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testTableWithCaptionAfterRows() throws Exception {
         // Given: Table with CAPTION after TR (invalid but common)
-        final String html = "<html><body><table>" + "<tr><td>Cell</td></tr>" + "<caption>Table Caption</caption>" + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Cell</td></tr>" + "<caption>Table Caption</caption>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -168,8 +171,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testFormWithOrphanedInputs() throws Exception {
         // Given: Form with inputs outside form tag
-        final String html = "<html><body>" + "<form action=\"#\">" + "<input type=\"text\" name=\"inside\">" + "</form>"
-                + "<input type=\"text\" name=\"outside\">" + "</body></html>";
+        final String html =
+                "<html><body>" + "<form action=\"#\">" + "<input type=\"text\" name=\"inside\">" + "</form>"
+                        + "<input type=\"text\" name=\"outside\">" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -182,8 +186,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testNestedForms() throws Exception {
         // Given: Nested forms (invalid HTML but may appear)
-        final String html = "<html><body>" + "<form action=\"outer\">" + "<form action=\"inner\">" + "<input type=\"text\">" + "</form>"
-                + "</form>" + "</body></html>";
+        final String html =
+                "<html><body>" + "<form action=\"outer\">" + "<form action=\"inner\">" + "<input type=\"text\">" + "</form>" + "</form>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -196,8 +201,8 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testFormWithSelectWithoutClosingOption() throws Exception {
         // Given: SELECT with unclosed OPTION tags
-        final String html = "<html><body>" + "<select>" + "<option>Option 1" + "<option>Option 2" + "<option>Option 3" + "</select>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<select>" + "<option>Option 1" + "<option>Option 2" + "<option>Option 3" + "</select>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -227,8 +232,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testNestedListsWithUnclosedItems() throws Exception {
         // Given: Nested lists with unclosed LI
-        final String html = "<html><body>" + "<ul>" + "<li>Item 1" + "<ul>" + "<li>Nested 1" + "<li>Nested 2" + "</ul>" + "<li>Item 2"
-                + "</ul>" + "</body></html>";
+        final String html =
+                "<html><body>" + "<ul>" + "<li>Item 1" + "<ul>" + "<li>Nested 1" + "<li>Nested 2" + "</ul>" + "<li>Item 2" + "</ul>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -241,8 +247,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testDefinitionListQuirks() throws Exception {
         // Given: DL with unclosed DT/DD
-        final String html = "<html><body>" + "<dl>" + "<dt>Term 1" + "<dd>Definition 1" + "<dt>Term 2" + "<dd>Definition 2" + "</dl>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<dl>" + "<dt>Term 1" + "<dd>Definition 1" + "<dt>Term 2" + "<dd>Definition 2" + "</dl>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -333,8 +340,8 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testScriptInBody() throws Exception {
         // Given: Script in body (valid but tested for quirks)
-        final String html = "<html><body>" + "<p>Before script</p>" + "<script>var x = 1;</script>" + "<p>After script</p>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<p>Before script</p>" + "<script>var x = 1;</script>" + "<p>After script</p>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -431,8 +438,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testHTML4StrictDoctype() throws Exception {
         // Given: HTML 4.01 Strict DOCTYPE
-        final String html = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
-                + "\"http://www.w3.org/TR/html4/strict.dtd\">" + "<html><body><p>HTML 4.01</p></body></html>";
+        final String html =
+                "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" " + "\"http://www.w3.org/TR/html4/strict.dtd\">"
+                        + "<html><body><p>HTML 4.01</p></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -444,8 +452,9 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testXHTMLDoctype() throws Exception {
         // Given: XHTML DOCTYPE
-        final String html = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-                + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" + "<html><body><p>XHTML</p></body></html>";
+        final String html =
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" " + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
+                        + "<html><body><p>XHTML</p></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -486,7 +495,8 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testMetaContentType() throws Exception {
         // Given: Legacy content-type meta
-        final String html = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Test</body></html>";
+        final String html =
+                "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Test</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -516,7 +526,8 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testVoidElementsWithSlash() throws Exception {
         // Given: Void elements with trailing slash (XHTML style)
-        final String html = "<html><body>" + "<br />" + "<hr />" + "<img src=\"test.png\" />" + "<input type=\"text\" />" + "</body></html>";
+        final String html =
+                "<html><body>" + "<br />" + "<hr />" + "<img src=\"test.png\" />" + "<input type=\"text\" />" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -533,12 +544,13 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testTypicalWebPageStructure() throws Exception {
         // Given: Typical web page structure
-        final String html = "<!DOCTYPE html>" + "<html lang=\"en\">" + "<head>" + "<meta charset=\"UTF-8\">"
-                + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + "<title>Test Page</title>"
-                + "<link rel=\"stylesheet\" href=\"style.css\">" + "<script src=\"script.js\"></script>" + "</head>" + "<body>" + "<header>"
-                + "<nav><ul><li><a href=\"#\">Home</a></li></ul></nav>" + "</header>" + "<main>" + "<article>"
-                + "<h1>Article Title</h1>" + "<p>Article content.</p>" + "</article>" + "</main>" + "<footer>"
-                + "<p>&copy; 2024</p>" + "</footer>" + "</body>" + "</html>";
+        final String html =
+                "<!DOCTYPE html>" + "<html lang=\"en\">" + "<head>" + "<meta charset=\"UTF-8\">"
+                        + "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">" + "<title>Test Page</title>"
+                        + "<link rel=\"stylesheet\" href=\"style.css\">" + "<script src=\"script.js\"></script>" + "</head>" + "<body>"
+                        + "<header>" + "<nav><ul><li><a href=\"#\">Home</a></li></ul></nav>" + "</header>" + "<main>" + "<article>"
+                        + "<h1>Article Title</h1>" + "<p>Article content.</p>" + "</article>" + "</main>" + "<footer>"
+                        + "<p>&copy; 2024</p>" + "</footer>" + "</body>" + "</html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -553,11 +565,11 @@ public class BrowserQuirksIntegrationTest {
     @Test
     public void testTypicalFormStructure() throws Exception {
         // Given: Typical form structure
-        final String html = "<html><body>" + "<form action=\"/submit\" method=\"post\">" + "<fieldset>"
-                + "<legend>User Information</legend>" + "<label for=\"name\">Name:</label>"
-                + "<input type=\"text\" id=\"name\" name=\"name\">" + "<label for=\"email\">Email:</label>"
-                + "<input type=\"email\" id=\"email\" name=\"email\">" + "</fieldset>" + "<button type=\"submit\">Submit</button>"
-                + "</form>" + "</body></html>";
+        final String html =
+                "<html><body>" + "<form action=\"/submit\" method=\"post\">" + "<fieldset>" + "<legend>User Information</legend>"
+                        + "<label for=\"name\">Name:</label>" + "<input type=\"text\" id=\"name\" name=\"name\">"
+                        + "<label for=\"email\">Email:</label>" + "<input type=\"email\" id=\"email\" name=\"email\">" + "</fieldset>"
+                        + "<button type=\"submit\">Submit</button>" + "</form>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/parsers/ComplexTableStructuresTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ComplexTableStructuresTest.java
@@ -54,11 +54,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithAllSections() throws Exception {
         // Given: Table with THEAD, TBODY, TFOOT
-        final String html = "<html><body><table>"
-                + "<thead><tr><th>Header</th></tr></thead>"
-                + "<tbody><tr><td>Body</td></tr></tbody>"
-                + "<tfoot><tr><td>Footer</td></tr></tfoot>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<thead><tr><th>Header</th></tr></thead>" + "<tbody><tr><td>Body</td></tr></tbody>"
+                        + "<tfoot><tr><td>Footer</td></tr></tfoot>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -74,11 +72,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithMultipleTbody() throws Exception {
         // Given: Table with multiple TBODY elements (valid HTML5)
-        final String html = "<html><body><table>"
-                + "<tbody><tr><td>Group 1 Row 1</td></tr></tbody>"
-                + "<tbody><tr><td>Group 2 Row 1</td></tr></tbody>"
-                + "<tbody><tr><td>Group 3 Row 1</td></tr></tbody>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tbody><tr><td>Group 1 Row 1</td></tr></tbody>" + "<tbody><tr><td>Group 2 Row 1</td></tr></tbody>"
+                        + "<tbody><tr><td>Group 3 Row 1</td></tr></tbody>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -92,10 +88,8 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithCaption() throws Exception {
         // Given: Table with CAPTION
-        final String html = "<html><body><table>"
-                + "<caption>Table Caption</caption>"
-                + "<tr><td>Cell</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<caption>Table Caption</caption>" + "<tr><td>Cell</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -109,14 +103,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithColgroup() throws Exception {
         // Given: Table with COLGROUP and COL
-        final String html = "<html><body><table>"
-                + "<colgroup>"
-                + "<col style=\"background-color:red\">"
-                + "<col style=\"background-color:blue\">"
-                + "<col style=\"background-color:green\">"
-                + "</colgroup>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<colgroup>" + "<col style=\"background-color:red\">" + "<col style=\"background-color:blue\">"
+                        + "<col style=\"background-color:green\">" + "</colgroup>"
+                        + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -130,10 +120,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithColgroupSpan() throws Exception {
         // Given: COLGROUP with span attribute
-        final String html = "<html><body><table>"
-                + "<colgroup span=\"3\" style=\"background-color:yellow\"></colgroup>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<colgroup span=\"3\" style=\"background-color:yellow\"></colgroup>"
+                        + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -148,19 +137,11 @@ public class ComplexTableStructuresTest {
     @Test
     public void testComplexTableWithAllElements() throws Exception {
         // Given: Complex table with all possible elements
-        final String html = "<html><body><table>"
-                + "<caption>Complete Table</caption>"
-                + "<colgroup>"
-                + "<col style=\"width:100px\">"
-                + "<col style=\"width:200px\">"
-                + "</colgroup>"
-                + "<thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>"
-                + "<tbody>"
-                + "<tr><td>Data 1-1</td><td>Data 1-2</td></tr>"
-                + "<tr><td>Data 2-1</td><td>Data 2-2</td></tr>"
-                + "</tbody>"
-                + "<tfoot><tr><td>Footer 1</td><td>Footer 2</td></tr></tfoot>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<caption>Complete Table</caption>" + "<colgroup>" + "<col style=\"width:100px\">"
+                        + "<col style=\"width:200px\">" + "</colgroup>" + "<thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>"
+                        + "<tbody>" + "<tr><td>Data 1-1</td><td>Data 1-2</td></tr>" + "<tr><td>Data 2-1</td><td>Data 2-2</td></tr>"
+                        + "</tbody>" + "<tfoot><tr><td>Footer 1</td><td>Footer 2</td></tr></tfoot>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -182,10 +163,7 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithTrDirectlyInTable() throws Exception {
         // Given: TR directly in TABLE (missing TBODY)
-        final String html = "<html><body><table>"
-                + "<tr><td>Cell 1</td></tr>"
-                + "<tr><td>Cell 2</td></tr>"
-                + "</table></body></html>";
+        final String html = "<html><body><table>" + "<tr><td>Cell 1</td></tr>" + "<tr><td>Cell 2</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -200,10 +178,7 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithTdDirectlyInTable() throws Exception {
         // Given: TD directly in TABLE (missing TBODY and TR)
-        final String html = "<html><body><table>"
-                + "<td>Cell 1</td>"
-                + "<td>Cell 2</td>"
-                + "</table></body></html>";
+        final String html = "<html><body><table>" + "<td>Cell 1</td>" + "<td>Cell 2</td>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -217,10 +192,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithTheadAfterTbody() throws Exception {
         // Given: THEAD after TBODY (incorrect order)
-        final String html = "<html><body><table>"
-                + "<tbody><tr><td>Body</td></tr></tbody>"
-                + "<thead><tr><th>Header</th></tr></thead>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tbody><tr><td>Body</td></tr></tbody>" + "<thead><tr><th>Header</th></tr></thead>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -234,13 +208,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithMixedElements() throws Exception {
         // Given: Table with elements in mixed/wrong order
-        final String html = "<html><body><table>"
-                + "<tr><td>Row 1</td></tr>"
-                + "<thead><tr><th>Header</th></tr></thead>"
-                + "<tr><td>Row 2</td></tr>"
-                + "<tfoot><tr><td>Footer</td></tr></tfoot>"
-                + "<tr><td>Row 3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Row 1</td></tr>" + "<thead><tr><th>Header</th></tr></thead>" + "<tr><td>Row 2</td></tr>"
+                        + "<tfoot><tr><td>Footer</td></tr></tfoot>" + "<tr><td>Row 3</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -253,11 +223,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithUnclosedRows() throws Exception {
         // Given: Table with unclosed TR tags
-        final String html = "<html><body><table>"
-                + "<tr><td>Cell 1-1</td><td>Cell 1-2</td>"
-                + "<tr><td>Cell 2-1</td><td>Cell 2-2</td>"
-                + "<tr><td>Cell 3-1</td><td>Cell 3-2</td>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Cell 1-1</td><td>Cell 1-2</td>" + "<tr><td>Cell 2-1</td><td>Cell 2-2</td>"
+                        + "<tr><td>Cell 3-1</td><td>Cell 3-2</td>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -271,9 +239,7 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithUnclosedCells() throws Exception {
         // Given: Table with unclosed TD tags
-        final String html = "<html><body><table>"
-                + "<tr><td>Cell 1<td>Cell 2<td>Cell 3</tr>"
-                + "</table></body></html>";
+        final String html = "<html><body><table>" + "<tr><td>Cell 1<td>Cell 2<td>Cell 3</tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -290,10 +256,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithColspan() throws Exception {
         // Given: Table with COLSPAN
-        final String html = "<html><body><table>"
-                + "<tr><td colspan=\"2\">Spans 2 columns</td><td>Cell 3</td></tr>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td colspan=\"2\">Spans 2 columns</td><td>Cell 3</td></tr>"
+                        + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -310,10 +275,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithRowspan() throws Exception {
         // Given: Table with ROWSPAN
-        final String html = "<html><body><table>"
-                + "<tr><td rowspan=\"2\">Spans 2 rows</td><td>Cell 1-2</td></tr>"
-                + "<tr><td>Cell 2-2</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td rowspan=\"2\">Spans 2 rows</td><td>Cell 1-2</td></tr>" + "<tr><td>Cell 2-2</td></tr>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -330,11 +294,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithComplexSpans() throws Exception {
         // Given: Table with complex COLSPAN and ROWSPAN
-        final String html = "<html><body><table>"
-                + "<tr><td colspan=\"2\" rowspan=\"2\">Spans 2x2</td><td>Cell 1-3</td></tr>"
-                + "<tr><td>Cell 2-3</td></tr>"
-                + "<tr><td>Cell 3-1</td><td>Cell 3-2</td><td>Cell 3-3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td colspan=\"2\" rowspan=\"2\">Spans 2x2</td><td>Cell 1-3</td></tr>"
+                        + "<tr><td>Cell 2-3</td></tr>" + "<tr><td>Cell 3-1</td><td>Cell 3-2</td><td>Cell 3-3</td></tr>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -352,10 +315,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithZeroSpan() throws Exception {
         // Given: Table with colspan/rowspan=0 (special value)
-        final String html = "<html><body><table>"
-                + "<tr><td colspan=\"0\">Spans to end</td></tr>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td colspan=\"0\">Spans to end</td></tr>"
+                        + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -369,9 +331,7 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithVeryLargeSpan() throws Exception {
         // Given: Table with very large span value
-        final String html = "<html><body><table>"
-                + "<tr><td colspan=\"1000\">Large span</td></tr>"
-                + "</table></body></html>";
+        final String html = "<html><body><table>" + "<tr><td colspan=\"1000\">Large span</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -389,10 +349,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testNestedTables2Levels() throws Exception {
         // Given: 2 levels of nested tables
-        final String html = "<html><body><table>"
-                + "<tr><td>Outer cell 1</td>"
-                + "<td><table><tr><td>Inner cell</td></tr></table></td>"
-                + "</tr></table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Outer cell 1</td>" + "<td><table><tr><td>Inner cell</td></tr></table></td>"
+                        + "</tr></table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -405,15 +364,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testNestedTables5Levels() throws Exception {
         // Given: 5 levels of nested tables
-        final String html = "<html><body><table><tr><td>"
-                + "<table><tr><td>"
-                + "<table><tr><td>"
-                + "<table><tr><td>"
-                + "<table><tr><td>Deep</td></tr></table>"
-                + "</td></tr></table>"
-                + "</td></tr></table>"
-                + "</td></tr></table>"
-                + "</td></tr></table></body></html>";
+        final String html =
+                "<html><body><table><tr><td>" + "<table><tr><td>" + "<table><tr><td>" + "<table><tr><td>"
+                        + "<table><tr><td>Deep</td></tr></table>" + "</td></tr></table>" + "</td></tr></table>" + "</td></tr></table>"
+                        + "</td></tr></table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -426,11 +380,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testNestedTableInTheadTbodyTfoot() throws Exception {
         // Given: Nested tables in different sections
-        final String html = "<html><body><table>"
-                + "<thead><tr><th><table><tr><td>Header table</td></tr></table></th></tr></thead>"
-                + "<tbody><tr><td><table><tr><td>Body table</td></tr></table></td></tr></tbody>"
-                + "<tfoot><tr><td><table><tr><td>Footer table</td></tr></table></td></tr></tfoot>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<thead><tr><th><table><tr><td>Header table</td></tr></table></th></tr></thead>"
+                        + "<tbody><tr><td><table><tr><td>Body table</td></tr></table></td></tr></tbody>"
+                        + "<tfoot><tr><td><table><tr><td>Footer table</td></tr></table></td></tr></tfoot>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -460,10 +413,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithEmptyCells() throws Exception {
         // Given: Table with empty cells
-        final String html = "<html><body><table>"
-                + "<tr><td></td><td></td><td></td></tr>"
-                + "<tr><td></td><td>Content</td><td></td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td></td><td></td><td></td></tr>" + "<tr><td></td><td>Content</td><td></td></tr>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -476,10 +428,7 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithOnlyTheadEmpty() throws Exception {
         // Given: Table with empty THEAD
-        final String html = "<html><body><table>"
-                + "<thead></thead>"
-                + "<tbody><tr><td>Body</td></tr></tbody>"
-                + "</table></body></html>";
+        final String html = "<html><body><table>" + "<thead></thead>" + "<tbody><tr><td>Body</td></tr></tbody>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -496,12 +445,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithThInTbody() throws Exception {
         // Given: TH elements in TBODY (valid for row headers)
-        final String html = "<html><body><table>"
-                + "<tbody>"
-                + "<tr><th>Row 1 Header</th><td>Data 1</td></tr>"
-                + "<tr><th>Row 2 Header</th><td>Data 2</td></tr>"
-                + "</tbody>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tbody>" + "<tr><th>Row 1 Header</th><td>Data 1</td></tr>"
+                        + "<tr><th>Row 2 Header</th><td>Data 2</td></tr>" + "</tbody>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -515,9 +461,8 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithOnlyTh() throws Exception {
         // Given: Table with only TH elements
-        final String html = "<html><body><table>"
-                + "<tr><th>Header 1</th><th>Header 2</th><th>Header 3</th></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><th>Header 1</th><th>Header 2</th><th>Header 3</th></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -531,10 +476,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithThAttributes() throws Exception {
         // Given: TH with scope, headers, and colspan attributes
-        final String html = "<html><body><table>"
-                + "<thead><tr><th id=\"h1\" scope=\"col\" colspan=\"2\">Header</th></tr></thead>"
-                + "<tbody><tr><td headers=\"h1\">Data 1</td><td headers=\"h1\">Data 2</td></tr></tbody>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<thead><tr><th id=\"h1\" scope=\"col\" colspan=\"2\">Header</th></tr></thead>"
+                        + "<tbody><tr><td headers=\"h1\">Data 1</td><td headers=\"h1\">Data 2</td></tr></tbody>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -554,17 +498,11 @@ public class ComplexTableStructuresTest {
     @Test
     public void testDataTableWithSorting() throws Exception {
         // Given: Data table with sorting attributes
-        final String html = "<html><body><table>"
-                + "<thead><tr>"
-                + "<th data-sort=\"string\">Name</th>"
-                + "<th data-sort=\"number\">Age</th>"
-                + "<th data-sort=\"date\">Date</th>"
-                + "</tr></thead>"
-                + "<tbody>"
-                + "<tr><td>John</td><td>30</td><td>2025-01-01</td></tr>"
-                + "<tr><td>Jane</td><td>25</td><td>2025-01-02</td></tr>"
-                + "</tbody>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<thead><tr>" + "<th data-sort=\"string\">Name</th>" + "<th data-sort=\"number\">Age</th>"
+                        + "<th data-sort=\"date\">Date</th>" + "</tr></thead>" + "<tbody>"
+                        + "<tr><td>John</td><td>30</td><td>2025-01-01</td></tr>" + "<tr><td>Jane</td><td>25</td><td>2025-01-02</td></tr>"
+                        + "</tbody>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -581,11 +519,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithFormElements() throws Exception {
         // Given: Table containing form elements
-        final String html = "<html><body><table>"
-                + "<tr><td><input type=\"text\" name=\"field1\"></td></tr>"
-                + "<tr><td><select name=\"field2\"><option>Option 1</option></select></td></tr>"
-                + "<tr><td><textarea name=\"field3\"></textarea></td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td><input type=\"text\" name=\"field1\"></td></tr>"
+                        + "<tr><td><select name=\"field2\"><option>Option 1</option></select></td></tr>"
+                        + "<tr><td><textarea name=\"field3\"></textarea></td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -600,12 +537,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithComplexContent() throws Exception {
         // Given: Table with various content types
-        final String html = "<html><body><table>"
-                + "<tr><td><img src=\"image.jpg\" alt=\"Image\"></td></tr>"
-                + "<tr><td><a href=\"#\">Link</a></td></tr>"
-                + "<tr><td><ul><li>List item</li></ul></td></tr>"
-                + "<tr><td><div><p>Nested content</p></div></td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td><img src=\"image.jpg\" alt=\"Image\"></td></tr>"
+                        + "<tr><td><a href=\"#\">Link</a></td></tr>" + "<tr><td><ul><li>List item</li></ul></td></tr>"
+                        + "<tr><td><div><p>Nested content</p></div></td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -621,11 +556,9 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithMultipleCaption() throws Exception {
         // Given: Table with multiple CAPTION elements (invalid but should handle)
-        final String html = "<html><body><table>"
-                + "<caption>Caption 1</caption>"
-                + "<caption>Caption 2</caption>"
-                + "<tr><td>Cell</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<caption>Caption 1</caption>" + "<caption>Caption 2</caption>" + "<tr><td>Cell</td></tr>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -638,13 +571,10 @@ public class ComplexTableStructuresTest {
     @Test
     public void testTableWithIrregularRows() throws Exception {
         // Given: Table with rows of different cell counts
-        final String html = "<html><body><table>"
-                + "<tr><td>Cell 1</td></tr>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td></tr>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>"
-                + "<tr><td>Cell 1</td><td>Cell 2</td></tr>"
-                + "<tr><td>Cell 1</td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td>Cell 1</td></tr>" + "<tr><td>Cell 1</td><td>Cell 2</td></tr>"
+                        + "<tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr>" + "<tr><td>Cell 1</td><td>Cell 2</td></tr>"
+                        + "<tr><td>Cell 1</td></tr>" + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/parsers/StrictModeTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/StrictModeTest.java
@@ -260,8 +260,7 @@ public class StrictModeTest {
         handler.startElement("", "div", "DIV", new org.xml.sax.helpers.AttributesImpl());
 
         // End with wrong tag - should not throw in lenient mode
-        assertDoesNotThrow(() -> handler.endElement("", "span", "SPAN"),
-                "Lenient mode should handle mismatched end tag");
+        assertDoesNotThrow(() -> handler.endElement("", "span", "SPAN"), "Lenient mode should handle mismatched end tag");
     }
 
     @Test
@@ -275,8 +274,7 @@ public class StrictModeTest {
         handler.endDocument(); // Clear stack
 
         // End element with empty stack - should not throw
-        assertDoesNotThrow(() -> handler.endElement("", "div", "DIV"),
-                "Lenient mode should handle end tag with empty stack");
+        assertDoesNotThrow(() -> handler.endElement("", "div", "DIV"), "Lenient mode should handle end tag with empty stack");
     }
 
     @Test
@@ -287,8 +285,7 @@ public class StrictModeTest {
         final SAXToDOMHandler handler = new SAXToDOMHandler(builder);
 
         // Characters before startDocument - should not throw
-        assertDoesNotThrow(() -> handler.characters("test".toCharArray(), 0, 4),
-                "Should handle characters before startDocument");
+        assertDoesNotThrow(() -> handler.characters("test".toCharArray(), 0, 4), "Should handle characters before startDocument");
     }
 
     @Test
@@ -301,8 +298,7 @@ public class StrictModeTest {
         handler.startDocument();
         handler.startElement("", "html", "HTML", new org.xml.sax.helpers.AttributesImpl());
 
-        assertDoesNotThrow(() -> handler.comment("This is a comment".toCharArray(), 0, 17),
-                "Should handle comment in document");
+        assertDoesNotThrow(() -> handler.comment("This is a comment".toCharArray(), 0, 17), "Should handle comment in document");
     }
 
     @Test
@@ -345,9 +341,8 @@ public class StrictModeTest {
         handler.endElement("", "p", "P");
         handler.endElement("", "div", "DIV");
 
-        // Should complete without throwing
-        assertDoesNotThrow(() -> {
-        }, "Skip depth should handle nested skipped elements");
+        // Should complete without throwing - verify handler accepted nested elements in skip mode
+        assertDoesNotThrow(() -> handler.endDocument(), "Skip depth should handle nested skipped elements");
     }
 
     // =========================================================================
@@ -358,8 +353,9 @@ public class StrictModeTest {
     public void testDOMParserStrictModeWellFormed() throws Exception {
         System.setProperty(PROPERTY_DOM_STRICT, "true");
 
-        final String html = "<html>" + "<head><title>Well Formed</title></head>" + "<body>"
-                + "<div id=\"container\">" + "<p class=\"content\">Hello World</p>" + "</div>" + "</body>" + "</html>";
+        final String html =
+                "<html>" + "<head><title>Well Formed</title></head>" + "<body>" + "<div id=\"container\">"
+                        + "<p class=\"content\">Hello World</p>" + "</div>" + "</body>" + "</html>";
 
         final DOMParser parser = new DOMParser();
         parser.parse(new InputSource(new StringReader(html)));
@@ -451,8 +447,7 @@ public class StrictModeTest {
         }
 
         public boolean hasWarningContaining(String substring) {
-            return records.stream()
-                    .filter(r -> r.getLevel() == Level.WARNING)
+            return records.stream().filter(r -> r.getLevel() == Level.WARNING)
                     .anyMatch(r -> r.getMessage() != null && r.getMessage().contains(substring));
         }
 

--- a/src/test/java/org/codelibs/nekohtml/sax/AdoptionAgencyAlgorithmExtendedTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/AdoptionAgencyAlgorithmExtendedTest.java
@@ -58,22 +58,11 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testAllFormattingElementsBasic() throws Exception {
         // Given: HTML with all formatting elements
-        final String html = "<html><body>"
-                + "<a href=\"#\">Link</a>"
-                + "<b>Bold</b>"
-                + "<big>Big</big>"
-                + "<code>Code</code>"
-                + "<em>Emphasis</em>"
-                + "<font>Font</font>"
-                + "<i>Italic</i>"
-                + "<nobr>NoBreak</nobr>"
-                + "<s>Strike</s>"
-                + "<small>Small</small>"
-                + "<strike>Strike</strike>"
-                + "<strong>Strong</strong>"
-                + "<tt>Teletype</tt>"
-                + "<u>Underline</u>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<a href=\"#\">Link</a>" + "<b>Bold</b>" + "<big>Big</big>" + "<code>Code</code>" + "<em>Emphasis</em>"
+                        + "<font>Font</font>" + "<i>Italic</i>" + "<nobr>NoBreak</nobr>" + "<s>Strike</s>" + "<small>Small</small>"
+                        + "<strike>Strike</strike>" + "<strong>Strong</strong>" + "<tt>Teletype</tt>" + "<u>Underline</u>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -170,15 +159,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingElementsWithComplexBlockStructure() throws Exception {
         // Given: Formatting elements with complex block structure
-        final String html = "<html><body>"
-                + "<b>Start"
-                + "<div>Div 1"
-                + "<p>Para 1</p>"
-                + "<blockquote>Quote</blockquote>"
-                + "</div>"
-                + "<section>Section</section>"
-                + "End</b>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<b>Start" + "<div>Div 1" + "<p>Para 1</p>" + "<blockquote>Quote</blockquote>" + "</div>"
+                        + "<section>Section</section>" + "End</b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -199,10 +182,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingElementsWithIdenticalAttributes() throws Exception {
         // Given: Multiple formatting elements with same attributes
-        final String html = "<html><body>"
-                + "<a href=\"#1\" class=\"link\">Link 1 <div>Block</div> continues</a>"
-                + "<a href=\"#2\" class=\"link\">Link 2 <p>Para</p> continues</a>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<a href=\"#1\" class=\"link\">Link 1 <div>Block</div> continues</a>"
+                        + "<a href=\"#2\" class=\"link\">Link 2 <p>Para</p> continues</a>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -216,9 +198,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFontElementWithAttributes() throws Exception {
         // Given: FONT element with attributes crossing block
-        final String html = "<html><body>"
-                + "<font color=\"red\" size=\"3\">Red text <div>Block</div> continues</font>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<font color=\"red\" size=\"3\">Red text <div>Block</div> continues</font>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -271,10 +251,10 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testComplexTableWithFormattingElements() throws Exception {
         // Given: Complex table with formatting elements
-        final String html = "<html><body><table>"
-                + "<tr><td><b>Bold</b></td><td><i>Italic</i></td></tr>"
-                + "<tr><td><strong>Strong <p>Para</p></strong></td><td><em>Em <div>Div</div></em></td></tr>"
-                + "</table></body></html>";
+        final String html =
+                "<html><body><table>" + "<tr><td><b>Bold</b></td><td><i>Italic</i></td></tr>"
+                        + "<tr><td><strong>Strong <p>Para</p></strong></td><td><em>Em <div>Div</div></em></td></tr>"
+                        + "</table></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -309,10 +289,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingElementInListItems() throws Exception {
         // Given: Formatting elements in list items
-        final String html = "<html><body><ul>"
-                + "<li><b>Bold <div>Block</div> continues</b></li>"
-                + "<li><i>Italic <p>Para</p> continues</i></li>"
-                + "</ul></body></html>";
+        final String html =
+                "<html><body><ul>" + "<li><b>Bold <div>Block</div> continues</b></li>" + "<li><i>Italic <p>Para</p> continues</i></li>"
+                        + "</ul></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -345,11 +324,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingElementsAcrossSemanticElements() throws Exception {
         // Given: Formatting elements crossing semantic boundaries
-        final String html = "<html><body><b>Bold "
-                + "<article>Article</article> "
-                + "<section>Section</section> "
-                + "<nav>Nav</nav> "
-                + "end</b></body></html>";
+        final String html =
+                "<html><body><b>Bold " + "<article>Article</article> " + "<section>Section</section> " + "<nav>Nav</nav> "
+                        + "end</b></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -365,13 +342,10 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testComplexSemanticStructureWithFormatting() throws Exception {
         // Given: Complex semantic structure with formatting
-        final String html = "<html><body>"
-                + "<article>"
-                + "<header><b>Header <h1>Title</h1> continues</b></header>"
-                + "<section><i>Section <p>Para</p> continues</i></section>"
-                + "<footer><strong>Footer <div>Div</div> continues</strong></footer>"
-                + "</article>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<article>" + "<header><b>Header <h1>Title</h1> continues</b></header>"
+                        + "<section><i>Section <p>Para</p> continues</i></section>"
+                        + "<footer><strong>Footer <div>Div</div> continues</strong></footer>" + "</article>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -455,9 +429,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testComplexMisnestingPattern() throws Exception {
         // Given: Very complex misnesting
-        final String html = "<html><body>"
-                + "<b><i><u><strong>Text<div>Block</strong></u></i></div></b>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<b><i><u><strong>Text<div>Block</strong></u></i></div></b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -537,11 +509,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testAllFormattingElementsTogether() throws Exception {
         // Given: All formatting elements used together
-        final String html = "<html><body>"
-                + "<b><i><u><strong><em><small><big><code><tt><s><strike>"
-                + "Text <div>Block</div> continues"
-                + "</strike></s></tt></code></big></small></em></strong></u></i></b>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<b><i><u><strong><em><small><big><code><tt><s><strike>" + "Text <div>Block</div> continues"
+                        + "</strike></s></tt></code></big></small></em></strong></u></i></b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -554,13 +524,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingElementsAcrossNestedBlocks() throws Exception {
         // Given: Formatting elements across deeply nested blocks
-        final String html = "<html><body><b>Start"
-                + "<div>Level 1"
-                + "<div>Level 2"
-                + "<div>Level 3"
-                + "<p>Para</p>"
-                + "</div></div></div>"
-                + "End</b></body></html>";
+        final String html =
+                "<html><body><b>Start" + "<div>Level 1" + "<div>Level 2" + "<div>Level 3" + "<p>Para</p>" + "</div></div></div>"
+                        + "End</b></body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -578,12 +544,8 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testAAAOuterLoopWithManyFormattingElements() throws Exception {
         // Given: More than 8 nested formatting elements to test outer loop limit
-        final String html = "<html><body>"
-                + "<b><i><u><s><em><strong><code><tt><big><small>"
-                + "Text"
-                + "</b>" // Close B early to trigger AAA
-                + "</small></big></tt></code></strong></em></s></u></i>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<b><i><u><s><em><strong><code><tt><big><small>" + "Text" + "</b>" // Close B early to trigger AAA
+                + "</small></big></tt></code></strong></em></s></u></i>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -618,12 +580,8 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testAAAWithAlternatingFormattingElements() throws Exception {
         // Given: Alternating formatting elements beyond loop limit
-        final String html = "<html><body>"
-                + "<b><i><b><i><b><i><b><i><b><i><b><i>"
-                + "Deep text"
-                + "</b>" // Early close
-                + "</i></b></i></b></i></b></i></b></i></b></i>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<b><i><b><i><b><i><b><i><b><i><b><i>" + "Deep text" + "</b>" // Early close
+                + "</i></b></i></b></i></b></i></b></i></b></i>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -639,14 +597,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingMarkerInTable() throws Exception {
         // Given: Formatting elements crossing table cell boundaries
-        final String html = "<html><body>"
-                + "<b>Before table"
-                + "<table>"
-                + "<tr><td>Cell 1 <i>Italic in cell</td>"
-                + "<td>Cell 2</i></td></tr>"
-                + "</table>"
-                + "After table</b>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<b>Before table" + "<table>" + "<tr><td>Cell 1 <i>Italic in cell</td>" + "<td>Cell 2</i></td></tr>"
+                        + "</table>" + "After table</b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -660,12 +613,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingMarkerInCaption() throws Exception {
         // Given: Formatting elements in table caption
-        final String html = "<html><body>"
-                + "<table>"
-                + "<caption><b>Bold caption <div>Block in caption</div> continues</b></caption>"
-                + "<tr><td>Cell</td></tr>"
-                + "</table>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<table>" + "<caption><b>Bold caption <div>Block in caption</div> continues</b></caption>"
+                        + "<tr><td>Cell</td></tr>" + "</table>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -678,12 +628,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingMarkerInTH() throws Exception {
         // Given: Formatting elements in table header
-        final String html = "<html><body>"
-                + "<table>"
-                + "<tr><th><b>Header <p>Para in header</p> continues</b></th></tr>"
-                + "<tr><td>Cell</td></tr>"
-                + "</table>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<table>" + "<tr><th><b>Header <p>Para in header</p> continues</b></th></tr>" + "<tr><td>Cell</td></tr>"
+                        + "</table>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -696,15 +643,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingAcrossMultipleTableCells() throws Exception {
         // Given: Formatting spanning multiple cells (invalid but should be handled)
-        final String html = "<html><body>"
-                + "<table>"
-                + "<tr>"
-                + "<td><b>Start bold</td>"
-                + "<td>Middle cell</b></td>"
-                + "<td>Third cell</td>"
-                + "</tr>"
-                + "</table>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<table>" + "<tr>" + "<td><b>Start bold</td>" + "<td>Middle cell</b></td>" + "<td>Third cell</td>"
+                        + "</tr>" + "</table>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -721,12 +662,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingInSelectOption() throws Exception {
         // Given: Formatting in select option (should be stripped)
-        final String html = "<html><body>"
-                + "<select>"
-                + "<option><b>Bold option</b></option>"
-                + "<option><i>Italic option</i></option>"
-                + "</select>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<select>" + "<option><b>Bold option</b></option>" + "<option><i>Italic option</i></option>" + "</select>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -740,11 +678,8 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingSpanningSelect() throws Exception {
         // Given: Formatting spanning across select (invalid)
-        final String html = "<html><body>"
-                + "<b>Before select"
-                + "<select><option>Option 1</option></select>"
-                + "After select</b>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<b>Before select" + "<select><option>Option 1</option></select>" + "After select</b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -761,9 +696,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingInButton() throws Exception {
         // Given: Formatting inside button
-        final String html = "<html><body>"
-                + "<button><b>Bold button <div>Block in button</div> text</b></button>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<button><b>Bold button <div>Block in button</div> text</b></button>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -776,11 +709,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingSpanningButton() throws Exception {
         // Given: Formatting spanning across button
-        final String html = "<html><body>"
-                + "<b>Before button"
-                + "<button>Click me</button>"
-                + "After button</b>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<b>Before button" + "<button>Click me</button>" + "After button</b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -797,9 +726,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingInObject() throws Exception {
         // Given: Formatting inside object element
-        final String html = "<html><body>"
-                + "<object><b>Fallback <div>Block</div> content</b></object>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<object><b>Fallback <div>Block</div> content</b></object>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -812,9 +739,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingInMarquee() throws Exception {
         // Given: Formatting in marquee (deprecated but may appear)
-        final String html = "<html><body>"
-                + "<marquee><b>Scrolling <div>Block</div> text</b></marquee>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<marquee><b>Scrolling <div>Block</div> text</b></marquee>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -831,11 +756,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingWithFormElement() throws Exception {
         // Given: Formatting crossing form boundary
-        final String html = "<html><body>"
-                + "<b>Before form"
-                + "<form><input type=\"text\"><div>Form content</div></form>"
-                + "After form</b>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<b>Before form" + "<form><input type=\"text\"><div>Form content</div></form>" + "After form</b>"
+                        + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -848,12 +771,9 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testFormattingWithFieldset() throws Exception {
         // Given: Formatting in fieldset with legend
-        final String html = "<html><body>"
-                + "<fieldset>"
-                + "<legend><b>Bold legend <div>Block</div></b></legend>"
-                + "<input type=\"text\">"
-                + "</fieldset>"
-                + "</body></html>";
+        final String html =
+                "<html><body>" + "<fieldset>" + "<legend><b>Bold legend <div>Block</div></b></legend>" + "<input type=\"text\">"
+                        + "</fieldset>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);
@@ -899,9 +819,7 @@ public class AdoptionAgencyAlgorithmExtendedTest {
     @Test
     public void testAAAWithMultipleFurthestBlockCandidates() throws Exception {
         // Given: Multiple potential furthest blocks
-        final String html = "<html><body>"
-                + "<b>Bold <p>Para 1</p> <div>Div</div> <p>Para 2</p> continues</b>"
-                + "</body></html>";
+        final String html = "<html><body>" + "<b>Bold <p>Para 1</p> <div>Div</div> <p>Para 2</p> continues</b>" + "</body></html>";
 
         // When: Parsing
         final Document doc = parseHTML(html);

--- a/src/test/java/org/codelibs/nekohtml/sax/HTMLSAXConfigurationTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/HTMLSAXConfigurationTest.java
@@ -214,13 +214,11 @@ public class HTMLSAXConfigurationTest {
         final HTMLSAXConfiguration config = new HTMLSAXConfiguration();
 
         // Default should be false
-        assertFalse(config.getFeature(HTMLSAXConfiguration.SIMPLE_ERROR_FORMAT),
-                "Simple error format should be disabled by default");
+        assertFalse(config.getFeature(HTMLSAXConfiguration.SIMPLE_ERROR_FORMAT), "Simple error format should be disabled by default");
 
         // Enable simple error format
         config.setFeature(HTMLSAXConfiguration.SIMPLE_ERROR_FORMAT, true);
-        assertTrue(config.getFeature(HTMLSAXConfiguration.SIMPLE_ERROR_FORMAT),
-                "Should be able to enable simple error format");
+        assertTrue(config.getFeature(HTMLSAXConfiguration.SIMPLE_ERROR_FORMAT), "Should be able to enable simple error format");
     }
 
     @Test
@@ -292,13 +290,11 @@ public class HTMLSAXConfigurationTest {
         final HTMLSAXConfiguration config = new HTMLSAXConfiguration();
 
         // Default should be "upper"
-        assertEquals("upper", config.getProperty(HTMLSAXConfiguration.NAMES_ELEMS),
-                "Element names should default to upper case");
+        assertEquals("upper", config.getProperty(HTMLSAXConfiguration.NAMES_ELEMS), "Element names should default to upper case");
 
         // Change to lower
         config.setProperty(HTMLSAXConfiguration.NAMES_ELEMS, "lower");
-        assertEquals("lower", config.getProperty(HTMLSAXConfiguration.NAMES_ELEMS),
-                "Should be able to set element names to lower case");
+        assertEquals("lower", config.getProperty(HTMLSAXConfiguration.NAMES_ELEMS), "Should be able to set element names to lower case");
     }
 
     @Test
@@ -306,13 +302,11 @@ public class HTMLSAXConfigurationTest {
         final HTMLSAXConfiguration config = new HTMLSAXConfiguration();
 
         // Default should be "lower"
-        assertEquals("lower", config.getProperty(HTMLSAXConfiguration.NAMES_ATTRS),
-                "Attribute names should default to lower case");
+        assertEquals("lower", config.getProperty(HTMLSAXConfiguration.NAMES_ATTRS), "Attribute names should default to lower case");
 
         // Change to upper
         config.setProperty(HTMLSAXConfiguration.NAMES_ATTRS, "upper");
-        assertEquals("upper", config.getProperty(HTMLSAXConfiguration.NAMES_ATTRS),
-                "Should be able to set attribute names to upper case");
+        assertEquals("upper", config.getProperty(HTMLSAXConfiguration.NAMES_ATTRS), "Should be able to set attribute names to upper case");
     }
 
     @Test
@@ -328,16 +322,14 @@ public class HTMLSAXConfigurationTest {
                 "Lexical handler should be retrievable via property");
 
         // Also get via getter
-        assertSame(lexHandler, config.getLexicalHandler(),
-                "Lexical handler should be retrievable via getter");
+        assertSame(lexHandler, config.getLexicalHandler(), "Lexical handler should be retrievable via getter");
     }
 
     @Test
     public void testUnrecognizedFeature() {
         final HTMLSAXConfiguration config = new HTMLSAXConfiguration();
 
-        assertThrows(org.xml.sax.SAXNotRecognizedException.class,
-                () -> config.getFeature("http://example.com/unknown-feature"),
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> config.getFeature("http://example.com/unknown-feature"),
                 "Should throw for unrecognized feature");
     }
 
@@ -345,8 +337,7 @@ public class HTMLSAXConfigurationTest {
     public void testUnrecognizedProperty() {
         final HTMLSAXConfiguration config = new HTMLSAXConfiguration();
 
-        assertThrows(org.xml.sax.SAXNotRecognizedException.class,
-                () -> config.getProperty("http://example.com/unknown-property"),
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> config.getProperty("http://example.com/unknown-property"),
                 "Should throw for unrecognized property");
     }
 

--- a/src/test/java/org/codelibs/nekohtml/sax/HTMLTagBalancerFilterEnhancementsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/HTMLTagBalancerFilterEnhancementsTest.java
@@ -46,8 +46,7 @@ public class HTMLTagBalancerFilterEnhancementsTest {
 
         filter.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(String uri, String localName, String qName, org.xml.sax.Attributes atts)
-                    throws SAXException {
+            public void startElement(String uri, String localName, String qName, org.xml.sax.Attributes atts) throws SAXException {
                 startElements.add(qName);
             }
 

--- a/src/test/java/org/codelibs/nekohtml/sax/RawTextElementsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/RawTextElementsTest.java
@@ -88,8 +88,9 @@ public class RawTextElementsTest {
 
     @Test
     public void testMultipleScriptElements() throws Exception {
-        final String html = "<html><head>" + "<script>var a = 1;</script>" + "<script>var b = 2;</script>"
-                + "<script>var c = 3;</script>" + "</head></html>";
+        final String html =
+                "<html><head>" + "<script>var a = 1;</script>" + "<script>var b = 2;</script>" + "<script>var c = 3;</script>"
+                        + "</head></html>";
 
         final DOMParser parser = new DOMParser();
         parser.parse(new InputSource(new StringReader(html)));
@@ -139,8 +140,7 @@ public class RawTextElementsTest {
         assertEquals(1, styles.getLength(), "Should have one style element");
 
         final String styleContent = styles.item(0).getTextContent();
-        assertTrue(styleContent.contains("color: red") || styleContent.contains("color:"),
-                "Style content should contain CSS rules");
+        assertTrue(styleContent.contains("color: red") || styleContent.contains("color:"), "Style content should contain CSS rules");
     }
 
     @Test

--- a/src/test/java/org/codelibs/nekohtml/sax/SimpleHTMLScannerEnhancementsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/SimpleHTMLScannerEnhancementsTest.java
@@ -477,9 +477,13 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        // Entities may be passed through or decoded depending on implementation
-        assertTrue(result.toString().contains("&") || result.toString().contains("&amp;"),
-                "Should handle ampersand entity");
+        // Entity decoding should produce actual characters
+        final String decoded = result.toString();
+        assertTrue(decoded.contains("&"), "Should decode &amp; to &");
+        assertTrue(decoded.contains("<"), "Should decode &lt; to <");
+        assertTrue(decoded.contains(">"), "Should decode &gt; to >");
+        assertTrue(decoded.contains("\""), "Should decode &quot; to \"");
+        assertTrue(decoded.contains("\u00A0"), "Should decode &nbsp; to non-breaking space");
     }
 
     /**
@@ -502,7 +506,11 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertNotNull(result.toString(), "Should parse decimal numeric entities");
+        // &#60; = <, &#62; = >, &#38; = &
+        final String decoded = result.toString();
+        assertTrue(decoded.contains("<"), "Should decode &#60; to <");
+        assertTrue(decoded.contains(">"), "Should decode &#62; to >");
+        assertTrue(decoded.contains("&"), "Should decode &#38; to &");
     }
 
     /**
@@ -525,7 +533,11 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertNotNull(result.toString(), "Should parse hexadecimal numeric entities");
+        // &#x3C; = <, &#x3E; = >, &#x26; = &
+        final String decoded = result.toString();
+        assertTrue(decoded.contains("<"), "Should decode &#x3C; to <");
+        assertTrue(decoded.contains(">"), "Should decode &#x3E; to >");
+        assertTrue(decoded.contains("&"), "Should decode &#x26; to &");
     }
 
     /**
@@ -550,7 +562,8 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(attrValues.toString().contains("href"), "Should parse attribute with entity");
+        final String attrs = attrValues.toString();
+        assertTrue(attrs.contains("href=test?a=1&b=2"), "Should decode &amp; in attribute to &");
     }
 
     /**
@@ -574,8 +587,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("&") || result.toString().contains("A"),
-                "Should handle incomplete entity");
+        assertTrue(result.toString().contains("A & B"), "Should preserve incomplete entity as literal text");
     }
 
     /**
@@ -598,7 +610,91 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertNotNull(result.toString(), "Should handle unknown entity");
+        assertTrue(result.toString().contains("&unknown;"), "Should preserve unknown entity as literal text");
+    }
+
+    /**
+     * Test that semicolon-less named entities in URL attributes are NOT decoded
+     * (HTML5 attribute value state rule: &not=, &copy=, &reg= must be preserved)
+     */
+    @Test
+    public void testSemicolonlessEntitiesInUrlAttributes() throws Exception {
+        final SimpleHTMLScanner scanner = new SimpleHTMLScanner();
+        final StringBuilder attrValues = new StringBuilder();
+
+        scanner.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(String uri, String localName, String qName, org.xml.sax.Attributes atts) {
+                for (int i = 0; i < atts.getLength(); i++) {
+                    attrValues.append(atts.getQName(i)).append("=").append(atts.getValue(i)).append("|");
+                }
+            }
+        });
+
+        final String html = "<a href=\"/x?a=1&not=2&copy=3&reg=4\">Link</a>";
+        final InputSource input = new InputSource(new StringReader(html));
+
+        scanner.parse(input);
+
+        final String attrs = attrValues.toString();
+        assertTrue(attrs.contains("href=/x?a=1&not=2&copy=3&reg=4"),
+                "Semicolon-less named entities in attributes should be preserved as-is, got: " + attrs);
+    }
+
+    /**
+     * Test that invalid numeric references produce U+FFFD replacement character
+     */
+    @Test
+    public void testInvalidNumericReferences() throws Exception {
+        final SimpleHTMLScanner scanner = new SimpleHTMLScanner();
+        final StringBuilder result = new StringBuilder();
+
+        scanner.setContentHandler(new DefaultHandler() {
+            @Override
+            public void characters(char[] ch, int start, int length) {
+                result.append(new String(ch, start, length));
+            }
+        });
+
+        // &#0; (null), &#xD800; (surrogate), &#x1; (control char)
+        final String html = "<html><body>&#0; &#xD800; &#x1;</body></html>";
+        final InputSource input = new InputSource(new StringReader(html));
+
+        scanner.parse(input);
+
+        final String decoded = result.toString();
+        // All invalid code points should be replaced with U+FFFD
+        assertEquals(
+                3,
+                decoded.chars().filter(c -> c == 0xFFFD).count(),
+                "Invalid numeric references should be replaced with U+FFFD, got: "
+                        + decoded.codePoints().mapToObj(cp -> String.format("U+%04X", cp)).reduce("", (a, b) -> a + " " + b));
+    }
+
+    /**
+     * Test that semicolon-less named entities ARE decoded in text context
+     */
+    @Test
+    public void testSemicolonlessEntitiesInTextContent() throws Exception {
+        final SimpleHTMLScanner scanner = new SimpleHTMLScanner();
+        final StringBuilder result = new StringBuilder();
+
+        scanner.setContentHandler(new DefaultHandler() {
+            @Override
+            public void characters(char[] ch, int start, int length) {
+                result.append(new String(ch, start, length));
+            }
+        });
+
+        final String html = "<html><body>&amp &lt &gt</body></html>";
+        final InputSource input = new InputSource(new StringReader(html));
+
+        scanner.parse(input);
+
+        final String decoded = result.toString();
+        assertTrue(decoded.contains("&"), "Should decode &amp (without semicolon) in text");
+        assertTrue(decoded.contains("<"), "Should decode &lt (without semicolon) in text");
+        assertTrue(decoded.contains(">"), "Should decode &gt (without semicolon) in text");
     }
 
     // =========================================================================
@@ -622,15 +718,13 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         // ISO-8859-1 encoded content with accented characters
         final String content = "café résumé";
-        final ByteArrayInputStream stream = new ByteArrayInputStream(
-                ("<html><body>" + content + "</body></html>").getBytes("ISO-8859-1"));
+        final ByteArrayInputStream stream = new ByteArrayInputStream(("<html><body>" + content + "</body></html>").getBytes("ISO-8859-1"));
         final InputSource input = new InputSource(stream);
         input.setEncoding("ISO-8859-1");
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("caf") || result.toString().contains("é"),
-                "ISO-8859-1 encoded content should be parsed");
+        assertTrue(result.toString().contains("caf") || result.toString().contains("é"), "ISO-8859-1 encoded content should be parsed");
     }
 
     /**
@@ -655,8 +749,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("Unicode") || result.toString().contains("\u4E2D"),
-                "UTF-16 encoded content should be parsed");
+        assertTrue(result.toString().contains("Unicode") || result.toString().contains("\u4E2D"), "UTF-16 encoded content should be parsed");
     }
 
     /**
@@ -681,8 +774,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("UTF-8") || result.toString().contains("ä"),
-                "Default UTF-8 encoding should work");
+        assertTrue(result.toString().contains("UTF-8") || result.toString().contains("ä"), "Default UTF-8 encoding should work");
     }
 
     /**
@@ -709,8 +801,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("From character stream"),
-                "Character stream should take precedence over byte stream");
+        assertTrue(result.toString().contains("From character stream"), "Character stream should take precedence over byte stream");
     }
 
     // =========================================================================
@@ -745,8 +836,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(input);
 
-        assertTrue(result.toString().contains("File URL content"),
-                "Should parse content from file:// URL");
+        assertTrue(result.toString().contains("File URL content"), "Should parse content from file:// URL");
     }
 
     /**
@@ -760,8 +850,7 @@ public class SimpleHTMLScannerEnhancementsTest {
         // InputSource with nothing set
         final InputSource input = new InputSource();
 
-        assertThrows(SAXException.class, () -> scanner.parse(input),
-                "Should throw when no valid input source is available");
+        assertThrows(SAXException.class, () -> scanner.parse(input), "Should throw when no valid input source is available");
     }
 
     /**
@@ -788,8 +877,7 @@ public class SimpleHTMLScannerEnhancementsTest {
 
         scanner.parse(tempFile.getAbsolutePath());
 
-        assertTrue(result.toString().contains("SystemId parse"),
-                "Should parse using String systemId parameter");
+        assertTrue(result.toString().contains("SystemId parse"), "Should parse using String systemId parameter");
     }
 
     // =========================================================================
@@ -900,8 +988,7 @@ public class SimpleHTMLScannerEnhancementsTest {
     public void testGetUnrecognizedFeature() {
         final SimpleHTMLScanner scanner = new SimpleHTMLScanner();
 
-        assertThrows(org.xml.sax.SAXNotRecognizedException.class,
-                () -> scanner.getFeature("http://example.com/unknown-feature"),
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> scanner.getFeature("http://example.com/unknown-feature"),
                 "Should throw SAXNotRecognizedException for unknown feature");
     }
 
@@ -912,8 +999,7 @@ public class SimpleHTMLScannerEnhancementsTest {
     public void testGetUnrecognizedProperty() {
         final SimpleHTMLScanner scanner = new SimpleHTMLScanner();
 
-        assertThrows(org.xml.sax.SAXNotRecognizedException.class,
-                () -> scanner.getProperty("http://example.com/unknown-property"),
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> scanner.getProperty("http://example.com/unknown-property"),
                 "Should throw SAXNotRecognizedException for unknown property");
     }
 
@@ -929,7 +1015,6 @@ public class SimpleHTMLScannerEnhancementsTest {
         final InputSource input = new InputSource(new StringReader(html));
 
         // Should return early without error
-        assertDoesNotThrow(() -> scanner.parse(input),
-                "Parsing without content handler should not throw");
+        assertDoesNotThrow(() -> scanner.parse(input), "Parsing without content handler should not throw");
     }
 }

--- a/src/test/java/org/codelibs/nekohtml/sax/SimpleHTMLScannerTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/SimpleHTMLScannerTest.java
@@ -407,8 +407,9 @@ public class SimpleHTMLScannerTest {
         // When: Parsing the HTML
         scanner.parse(input);
 
-        // Then: Should capture special characters (as-is, no entity decoding)
-        assertTrue(textContent.stream().anyMatch(text -> text.contains("&lt;&gt;&amp;")));
+        // Then: Should capture decoded special characters (join chunks since characters() may be called multiple times)
+        final String allText = String.join("", textContent);
+        assertTrue(allText.contains("<>&"), "Should decode &lt;&gt;&amp; to <>&");
     }
 
     @Test
@@ -499,8 +500,8 @@ public class SimpleHTMLScannerTest {
         final SAXException exception = assertThrows(SAXException.class, () -> {
             scanner.parse(input);
         });
-        assertTrue(exception.getMessage().contains("Cannot open SystemId"),
-                "Expected message about unable to open SystemId, got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("Cannot open SystemId"), "Expected message about unable to open SystemId, got: "
+                + exception.getMessage());
     }
 
     @Test
@@ -525,8 +526,8 @@ public class SimpleHTMLScannerTest {
         final SAXException exception = assertThrows(SAXException.class, () -> {
             scanner.parse("http://example.com/nonexistent.html");
         });
-        assertTrue(exception.getMessage().contains("Cannot open SystemId"),
-                "Expected message about unable to open SystemId, got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("Cannot open SystemId"), "Expected message about unable to open SystemId, got: "
+                + exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements HTML character entity resolution directly in `SimpleHTMLScanner`, decoding entities in both text content and attribute values during parsing.

## Changes Made

- Added `resolveEntities(String text)` and `resolveEntities(String text, boolean inAttribute)` methods to `SimpleHTMLScanner`
- Added static `ENTITY_PATTERN` regex covering decimal (`&#214;`), hex (`&#xD6;`), and named (`&Ouml;`) entity references with optional trailing semicolons
- Added `resolveCodePoint()` helper that replaces invalid/noncharacter code points with U+FFFD per the HTML5 spec
- Text content: entities are always resolved before dispatching `characters()` events
- Attribute values: semicolon-less named entities followed by `[A-Za-z0-9=]` are intentionally left unresolved to avoid corrupting URLs (e.g. `&not=`, `&copy=`)
- Updated all affected tests to expect correctly entity-resolved output

## Testing

- Existing test suite updated to reflect resolved entity output
- Tests cover numeric decimal/hex entities, named entities, edge cases (null char, surrogates, out-of-Unicode-range, XML-illegal chars, Unicode noncharacters)

## Breaking Changes

- Text content and attribute values that previously contained literal `&...;` sequences will now be emitted as their decoded Unicode equivalents. Consumers relying on raw entity text in SAX events will need to re-evaluate, but this aligns with correct HTML parsing behavior.

## Additional Notes

- Uses `HTMLEntities.get()` for named entity lookup — no new dependencies introduced
- Attribute context handling follows the HTML5 tokenizer attribute value state spec to avoid false positives on query strings and URL parameters