### PR TITLE
feat(build): add OSGi bundle support

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,20 @@
+Bundle-SymbolicName: org.codelibs.nekohtml
+Bundle-Name: Neko HTML
+Bundle-Description: An HTML parser and tag balancer.
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
+Bundle-DocURL: https://github.com/codelibs/nekohtml
+Bundle-Vendor: CodeLibs Project
+
+Export-Package: \
+    org.codelibs.nekohtml;version="${project.version}",\
+    org.codelibs.nekohtml.parsers;version="${project.version}",\
+    org.codelibs.nekohtml.sax;version="${project.version}"
+
+Import-Package: \
+    javax.xml.parsers,\
+    org.w3c.dom,\
+    org.xml.sax,\
+    org.xml.sax.ext,\
+    org.xml.sax.helpers
+
+Automatic-Module-Name: org.codelibs.nekohtml

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>7.1.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -62,9 +74,7 @@
 				<version>3.4.2</version>
 				<configuration>
 					<archive>
-						<manifestEntries>
-							<Automatic-Module-Name>org.codelibs.nekohtml</Automatic-Module-Name>
-						</manifestEntries>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## Summary
Add OSGi bundle metadata generation using the bnd-maven-plugin, enabling NekoHTML to be used as an OSGi bundle in modular environments.

## Changes Made
- Add `bnd.bnd` descriptor with bundle metadata, exported packages, and import declarations
- Add `bnd-maven-plugin` (7.1.0) to `pom.xml` for automatic OSGi manifest generation
- Update `maven-jar-plugin` to use the bnd-generated `MANIFEST.MF` instead of manual `Automatic-Module-Name` entry

## Testing
- Build with `mvn clean package` to verify manifest generation
- Inspect `META-INF/MANIFEST.MF` in the output JAR for correct OSGi headers

## Breaking Changes
- None. The `Automatic-Module-Name` is preserved in `bnd.bnd`, maintaining JPMS compatibility.

## Additional Notes
- Zero new runtime dependencies — bnd-maven-plugin is build-time only