### PR TITLE
fix(sax): add private constructors to utility classes and fix Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
+					<legacyMode>true</legacyMode>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/codelibs/nekohtml/sax/EncodingMap.java
+++ b/src/main/java/org/codelibs/nekohtml/sax/EncodingMap.java
@@ -29,6 +29,10 @@ import java.util.Map;
  */
 public class EncodingMap {
 
+    /** Private constructor to prevent instantiation of utility class. */
+    private EncodingMap() {
+    }
+
     /** Mapping from IANA names to Java charset names. */
     private static final Map<String, String> IANA_TO_JAVA_MAP = new HashMap<>();
 

--- a/src/main/java/org/codelibs/nekohtml/sax/SimpleHTMLScanner.java
+++ b/src/main/java/org/codelibs/nekohtml/sax/SimpleHTMLScanner.java
@@ -49,6 +49,10 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public class SimpleHTMLScanner implements XMLReader {
 
+    /** Constructs a new SimpleHTMLScanner instance. */
+    public SimpleHTMLScanner() {
+    }
+
     /** Logger for this class. */
     private static final Logger logger = Logger.getLogger(SimpleHTMLScanner.class.getName());
 
@@ -457,7 +461,7 @@ public class SimpleHTMLScanner implements XMLReader {
      * Resolves HTML character entities in the given text.
      * Handles numeric decimal (&#214;), numeric hex (&#xD6;), and named (&Ouml;) entities.
      * In attribute context, semicolon-less named entities followed by [A-Za-z0-9=] are not decoded
-     * per HTML5 attribute value state rules, preventing corruption of URLs like &not=, &copy=.
+     * per HTML5 attribute value state rules, preventing corruption of URLs like {@code &not=, &copy=}.
      *
      * @param text The text containing entities
      * @param inAttribute Whether this text is an attribute value

--- a/src/main/java/org/codelibs/nekohtml/sax/XMLChar.java
+++ b/src/main/java/org/codelibs/nekohtml/sax/XMLChar.java
@@ -23,6 +23,10 @@ package org.codelibs.nekohtml.sax;
  */
 public class XMLChar {
 
+    /** Private constructor to prevent instantiation of utility class. */
+    private XMLChar() {
+    }
+
     /**
      * Checks if a character is a valid XML character according to XML 1.0.
      *

--- a/src/test/java/org/codelibs/nekohtml/sax/EncodingMapTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/EncodingMapTest.java
@@ -30,15 +30,6 @@ import org.junit.jupiter.api.Test;
 public class EncodingMapTest {
 
     @Test
-    public void testConstructor() {
-        // When: Creating EncodingMap instance
-        final EncodingMap map = new EncodingMap();
-
-        // Then: Instance should be created
-        assertNotNull(map, "EncodingMap should be instantiable");
-    }
-
-    @Test
     public void testGetIANA2JavaMappingUTF8() {
         // When: Getting mapping for UTF-8
         final String javaEncoding = EncodingMap.getIANA2JavaMapping("UTF-8");


### PR DESCRIPTION
## Summary

Code quality fixes for utility classes and Javadoc generation in the `sax` package.

## Changes Made

- **EncodingMap.java**: Added private constructor to prevent instantiation — `EncodingMap` is a static utility class and should not be instantiated
- **XMLChar.java**: Same utility class fix — added private constructor
- **SimpleHTMLScanner.java**: Added explicit public no-arg constructor to satisfy Javadoc strict mode; also fixed an inline code reference in Javadoc (`&not=` → `{@code &not=, &copy=}`)
- **pom.xml**: Enabled `<legacyMode>true</legacyMode>` in maven-javadoc-plugin to resolve Javadoc generation issues with newer JDK
- **EncodingMapTest.java**: Removed `testConstructor()` which tested public instantiation of what is now a non-instantiable utility class

## Testing

The removed test was validating behavior (instantiability) that is now intentionally prohibited. All remaining tests cover the static API surface, which is unaffected.

## Breaking Changes

None — `EncodingMap` and `XMLChar` were not meant to be instantiated; this change enforces that contract. `SimpleHTMLScanner` retains its public constructor.

## Additional Notes

These changes align with standard Java utility class conventions and static analysis tool expectations (e.g., SonarQube HideUtilityClassConstructor rule).