### PR TITLE
chore(build): bump Maven plugins, Mockito, and gate GPG signing behind release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<release>17</release>
@@ -62,7 +62,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -72,7 +72,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -81,12 +81,12 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.5.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -140,23 +140,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -164,6 +150,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -174,13 +186,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.14.2</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>5.14.2</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/org/codelibs/nekohtml/ObjectFactoryCoverageTest.java
+++ b/src/test/java/org/codelibs/nekohtml/ObjectFactoryCoverageTest.java
@@ -97,8 +97,7 @@ public class ObjectFactoryCoverageTest {
             final Object result = ObjectFactory.createObject("com.example.Factory", null, "java.lang.String");
 
             assertNotNull(result);
-            assertTrue(result instanceof StringBuilder,
-                    "System property should take precedence over jar service provider");
+            assertTrue(result instanceof StringBuilder, "System property should take precedence over jar service provider");
         } finally {
             System.clearProperty("com.example.Factory");
         }
@@ -279,8 +278,7 @@ public class ObjectFactoryCoverageTest {
         };
 
         // restrictedCl can't find ObjectFactory, but fallback (ObjectFactory's own CL) can
-        final Class<?> clazz = ObjectFactory.findProviderClass(
-                "org.codelibs.nekohtml.ObjectFactory", restrictedCl, true);
+        final Class<?> clazz = ObjectFactory.findProviderClass("org.codelibs.nekohtml.ObjectFactory", restrictedCl, true);
 
         assertNotNull(clazz);
         assertEquals("org.codelibs.nekohtml.ObjectFactory", clazz.getName());
@@ -302,8 +300,7 @@ public class ObjectFactoryCoverageTest {
         final Object result = ObjectFactory.createObject("test.coverage.factory", propsFile.toString(), "java.lang.String");
 
         assertNotNull(result);
-        assertTrue(result instanceof StringBuilder,
-                "Should use class from properties file, not fallback");
+        assertTrue(result instanceof StringBuilder, "Should use class from properties file, not fallback");
     }
 
     @Test
@@ -318,19 +315,17 @@ public class ObjectFactoryCoverageTest {
         final Object result = ObjectFactory.createObject("test.coverage.factory", propsFile.toString(), "java.lang.String");
 
         assertNotNull(result);
-        assertTrue(result instanceof String,
-                "Should fall back when key not found in properties file");
+        assertTrue(result instanceof String, "Should fall back when key not found in properties file");
     }
 
     @Test
     public void testCreateObjectWithNonExistentPropertiesFile() {
         // Explicit properties file path that doesn't exist - should skip and use fallback
-        final Object result = ObjectFactory.createObject("test.coverage.factory",
-                "/nonexistent/path/to/properties.file", "java.lang.String");
+        final Object result =
+                ObjectFactory.createObject("test.coverage.factory", "/nonexistent/path/to/properties.file", "java.lang.String");
 
         assertNotNull(result);
-        assertTrue(result instanceof String,
-                "Should fall back when properties file doesn't exist");
+        assertTrue(result instanceof String, "Should fall back when properties file doesn't exist");
     }
 
     @Test
@@ -380,8 +375,7 @@ public class ObjectFactoryCoverageTest {
         // This class is on the app classpath but not bootstrap,
         // so emptyCl can't find it. With doFallback=true, it falls back
         // to ObjectFactory.class.getClassLoader()
-        final Object result = ObjectFactory.newInstance(
-                "org.codelibs.nekohtml.testclasses.SimpleProvider", emptyCl, true);
+        final Object result = ObjectFactory.newInstance("org.codelibs.nekohtml.testclasses.SimpleProvider", emptyCl, true);
 
         assertNotNull(result);
         assertEquals("org.codelibs.nekohtml.testclasses.SimpleProvider", result.getClass().getName());
@@ -432,8 +426,7 @@ public class ObjectFactoryCoverageTest {
 
         assertNotNull(fromTwoArg);
         assertNotNull(fromThreeArg);
-        assertEquals(fromTwoArg.getClass(), fromThreeArg.getClass(),
-                "Two-arg and three-arg should produce same class");
+        assertEquals(fromTwoArg.getClass(), fromThreeArg.getClass(), "Two-arg and three-arg should produce same class");
     }
 
     // -----------------------------------------------------------------------
@@ -473,8 +466,7 @@ public class ObjectFactoryCoverageTest {
         try {
             final Object result = ObjectFactory.createObject(factoryId, null, "java.lang.String");
             assertNotNull(result);
-            assertTrue(result instanceof java.util.HashMap,
-                    "Should use class from system property");
+            assertTrue(result instanceof java.util.HashMap, "Should use class from system property");
         } finally {
             System.clearProperty(factoryId);
         }
@@ -490,12 +482,10 @@ public class ObjectFactoryCoverageTest {
 
         System.setProperty("test.coverage.factory", "java.util.LinkedList");
         try {
-            final Object result = ObjectFactory.createObject("test.coverage.factory",
-                    propsFile.toString(), "java.lang.String");
+            final Object result = ObjectFactory.createObject("test.coverage.factory", propsFile.toString(), "java.lang.String");
 
             assertNotNull(result);
-            assertTrue(result instanceof java.util.LinkedList,
-                    "System property should take precedence over properties file");
+            assertTrue(result instanceof java.util.LinkedList, "System property should take precedence over properties file");
         } finally {
             System.clearProperty("test.coverage.factory");
         }

--- a/src/test/java/org/codelibs/nekohtml/parsers/SAXToDOMHandlerCoverageTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/SAXToDOMHandlerCoverageTest.java
@@ -98,8 +98,7 @@ public class SAXToDOMHandlerCoverageTest {
         System.setProperty(PROP_DOM_STRICT, "true");
         handler = new SAXToDOMHandler(documentBuilder);
 
-        final SAXException ex = assertThrows(SAXException.class,
-                () -> handler.startElement("", "div", "div", new AttributesImpl()));
+        final SAXException ex = assertThrows(SAXException.class, () -> handler.startElement("", "div", "div", new AttributesImpl()));
         assertTrue(ex.getMessage().contains("before startDocument()"));
     }
 
@@ -138,8 +137,7 @@ public class SAXToDOMHandlerCoverageTest {
         // But document is still set, so it goes past the null check.
         // We need document != null but stack empty.
         // After endDocument, elementStack.clear() is called, so stack is empty and document is set.
-        final SAXException ex = assertThrows(SAXException.class,
-                () -> handler.startElement("", "p", "p", new AttributesImpl()));
+        final SAXException ex = assertThrows(SAXException.class, () -> handler.startElement("", "p", "p", new AttributesImpl()));
         assertTrue(ex.getMessage().contains("empty element stack"));
     }
 
@@ -189,8 +187,7 @@ public class SAXToDOMHandlerCoverageTest {
         handler.endElement("", "html", "html");
         // Now stack has only Document. Document already has a document element.
         // Adding another element to Document should cause HIERARCHY_REQUEST_ERR.
-        final SAXException ex = assertThrows(SAXException.class,
-                () -> handler.startElement("", "extra", "extra", new AttributesImpl()));
+        final SAXException ex = assertThrows(SAXException.class, () -> handler.startElement("", "extra", "extra", new AttributesImpl()));
         assertTrue(ex.getMessage().contains("DOM hierarchy violation"));
     }
 

--- a/src/test/java/org/codelibs/nekohtml/sax/HTMLTagBalancerFilterCoverageTest.java
+++ b/src/test/java/org/codelibs/nekohtml/sax/HTMLTagBalancerFilterCoverageTest.java
@@ -147,9 +147,10 @@ public class HTMLTagBalancerFilterCoverageTest {
 
     @Test
     public void testIsSpecialElement_specialElements() {
-        String[] specialElements = { "ADDRESS", "ARTICLE", "ASIDE", "BLOCKQUOTE", "DETAILS", "DIALOG", "DIV", "DL", "FIELDSET",
-                "FIGCAPTION", "FIGURE", "FOOTER", "FORM", "H1", "H2", "H3", "H4", "H5", "H6", "HEADER", "HGROUP", "HR", "LI", "MAIN",
-                "NAV", "OL", "P", "PRE", "SEARCH", "SECTION", "TABLE", "UL" };
+        String[] specialElements =
+                { "ADDRESS", "ARTICLE", "ASIDE", "BLOCKQUOTE", "DETAILS", "DIALOG", "DIV", "DL", "FIELDSET", "FIGCAPTION", "FIGURE",
+                        "FOOTER", "FORM", "H1", "H2", "H3", "H4", "H5", "H6", "HEADER", "HGROUP", "HR", "LI", "MAIN", "NAV", "OL", "P",
+                        "PRE", "SEARCH", "SECTION", "TABLE", "UL" };
 
         for (String elem : specialElements) {
             assertTrue(filter.isSpecialElement(elem), elem + " should be special");
@@ -640,7 +641,7 @@ public class HTMLTagBalancerFilterCoverageTest {
     @Test
     public void testFindFurthestBlock_withBlock() {
         filter.elementStack.push("HTML");
-        filter.elementStack.push("B");   // index 1
+        filter.elementStack.push("B"); // index 1
         filter.elementStack.push("DIV"); // index 2 - special
 
         assertEquals(2, filter.findFurthestBlock(1));


### PR DESCRIPTION
## Summary
Routine maintenance of build tooling: bump several Maven plugins and Mockito, and move GPG signing into a `release` profile so day-to-day `mvn verify` no longer requires a GPG key.

## Changes Made
- Maven plugins
  - `maven-compiler-plugin` 3.14.0 → 3.15.0
  - `maven-javadoc-plugin` 3.11.2 → 3.12.0
  - `maven-jar-plugin` 3.4.2 → 3.5.0
  - `maven-surefire-plugin` 3.5.0 → 3.5.5
  - `jacoco-maven-plugin` 0.8.13 → 0.8.14
  - `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- Test deps
  - `mockito-core` and `mockito-junit-jupiter` 5.14.2 → 5.23.0
- Build configuration
  - Move `maven-gpg-plugin` (bumped to 3.2.8, `bestPractices=true`) out of the always-on `<build>` block and into a new `release` profile. Use `-Prelease` when cutting a release; normal builds skip signing.
- Apply formatter (`mvn formatter:format`) to recently added coverage tests.

## Testing
- `mvn clean verify` locally to confirm the build still passes without GPG configured.
- Release flow (`mvn -Prelease ...`) should be exercised when the next release is cut.

## Breaking Changes
- Release scripts/CI must now pass `-Prelease` to trigger artifact signing. The default verify build no longer signs.

## Additional Notes
- No production code changed; only `pom.xml` and formatting on three test classes.