### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,13 +66,14 @@ jobs:
     #- run: |
     #   make bootstrap
     #   make release
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: '11'
+        distribution: 'temurin'
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -81,4 +82,4 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Update outdated GitHub Actions in `.github/workflows/codeql-analysis.yml` to currently supported major versions:

- `actions/checkout`: v2 -> v4
- `actions/cache`: v2 -> v4
- `actions/setup-java`: v1 -> v4
- `github/codeql-action/init`: v1 -> v3
- `github/codeql-action/analyze`: v1 -> v3

The commented-out `github/codeql-action/autobuild@v1` reference was left as-is since it is not active.

`distribution: 'temurin'` was added to the `setup-java` step because `actions/setup-java@v4` requires the `distribution` input. The `java-version` value was quoted (`'11'`) to remain consistent with YAML string conventions.

## Test plan

- [ ] CodeQL workflow runs successfully on push/PR
- [ ] Maven build completes within the workflow on Temurin JDK 11
- [ ] CodeQL analysis uploads results without deprecation warnings