### PR TITLE
test: add characterization tests for HTML parsing (broken and valid input)

### DIFF
--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenAttributeSyntaxTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenAttributeSyntaxTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Characterization tests for broken/malformed attribute syntax (category H).
+ * These tests lock in the current regex-based attribute tokenization behavior;
+ * some of it is intentionally non-standard compared to a real HTML5 parser.
+ */
+public class BrokenAttributeSyntaxTest {
+
+    @Test
+    public void unquotedAttributesSplitOnWhitespace() throws Exception {
+        // characterization: unquoted values are split on whitespace; the next bare token becomes a valueless attribute
+        final Document doc = parse("<a b=c d>x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("c", a.getAttribute("b"));
+        assertEquals("", a.getAttribute("d"));
+    }
+
+    @Test
+    public void quotedGreaterThanEndsTagEarlyLeaksText() throws Exception {
+        // characterization: a '>' inside a quoted value ends the START_TAG match early;
+        // the quote character itself becomes part of the (unquoted) attribute value,
+        // and the remaining "y">" leaks as sibling text
+        final Document doc = parse("<a title=\"x>y\">");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("\"x", a.getAttribute("title"));
+        assertTrue(firstText(doc, "//HTML").contains("y\">"));
+    }
+
+    @Test
+    public void unterminatedQuoteAttributeValueKeepsLeadingQuote() throws Exception {
+        // characterization: an unterminated quoted value falls back to the unquoted alternative,
+        // so the leading quote character is preserved literally in the attribute value
+        final Document doc = parse("<a href=\"x>");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("\"x", a.getAttribute("href"));
+    }
+
+    @Test
+    public void duplicateAttributeLastValueWins() throws Exception {
+        // characterization: duplicate attribute names are all parsed, but DOM Element.setAttribute()
+        // is called once per occurrence in order, so the last occurrence wins
+        final Document doc = parse("<a id=1 id=2>x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("2", a.getAttribute("id"));
+    }
+
+    @Test
+    public void valuelessBooleanAttributeBecomesEmptyString() throws Exception {
+        final Document doc = parse("<input disabled>");
+        final Element input = first(doc, "//INPUT");
+        assertEquals("", input.getAttribute("disabled"));
+        assertTrue(input.hasAttribute("disabled"));
+    }
+
+    @Test
+    public void bareEqualsSignIsSkippedAndNextTokenBecomesAttribute() throws Exception {
+        // characterization: a stray leading '=' does not match the attribute-name pattern and is
+        // simply skipped; the following bare token is parsed as a normal valueless attribute
+        final Document doc = parse("<a =x>y</a>");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("", a.getAttribute("x"));
+        assertEquals(1, a.getAttributes().getLength());
+    }
+
+    @Test
+    public void multipleEqualsSignsAreKeptInUnquotedValue() throws Exception {
+        // characterization: unquoted value scanning does not stop at '=', so "a=b" is captured whole
+        final Document doc = parse("<div class=a=b>x</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("a=b", div.getAttribute("class"));
+    }
+
+    @Test
+    public void ampCopyPreservedInAttributeValue() throws Exception {
+        // characterization: a semicolon-less named entity followed by '=' is left undecoded in
+        // attribute context (HTML5 attribute-value-state rule), preventing URL corruption
+        final Document doc = parse("<a href=\"?x=1&copy=2\">x</a>");
+        assertTrue(first(doc, "//A").getAttribute("href").contains("&copy=2"));
+    }
+
+    @Test
+    public void attributeNameLowercasedValuePreserved() throws Exception {
+        final Document doc = parse("<a HREF=\"X\">x</a>");
+        final Element a = first(doc, "//A");
+        assertTrue(a.hasAttribute("href"));
+        assertFalse(a.hasAttribute("HREF"));
+        assertEquals("X", a.getAttribute("href"));
+    }
+
+    @Test
+    public void attributeSeparatedByNewlineInsideTag() throws Exception {
+        final Document doc = parse("<div\ndata-x=\"1\">x</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("1", div.getAttribute("data-x"));
+    }
+
+    @Test
+    public void doubleEqualsKeepsLeadingEqualsInValue() throws Exception {
+        // characterization: "b==c" is parsed as name "b" with unquoted value "=c"
+        final Document doc = parse("<a b==c>x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("=c", a.getAttribute("b"));
+    }
+
+    @Test
+    public void adjacentQuotedAttributesWithoutWhitespaceSeparator() throws Exception {
+        // characterization: no whitespace is required between a quoted value and the next attribute name
+        final Document doc = parse("<a b=\"c\"d=\"e\">x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("c", a.getAttribute("b"));
+        assertEquals("e", a.getAttribute("d"));
+    }
+
+    @Test
+    public void numericAttributeNamePrefixIsDropped() throws Exception {
+        // characterization: an attribute "name" cannot start with a digit; "123=" is silently skipped
+        // and only the trailing bare "x" is recognized as a valueless attribute
+        final Document doc = parse("<a 123=x>y</a>");
+        final Element a = first(doc, "//A");
+        assertEquals(1, a.getAttributes().getLength());
+        assertEquals("", a.getAttribute("x"));
+        assertFalse(a.hasAttribute("123"));
+    }
+
+    @Test
+    public void bareAttributeFollowedByAttributeWithValue() throws Exception {
+        final Document doc = parse("<a b c=d>x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("", a.getAttribute("b"));
+        assertEquals("d", a.getAttribute("c"));
+    }
+
+    @Test
+    public void selfClosingSlashIsNotParsedAsAttribute() throws Exception {
+        final Document doc = parse("<a href=\"x\" />y</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("x", a.getAttribute("href"));
+        assertEquals(1, a.getAttributes().getLength());
+    }
+
+    @Test
+    public void numericEntityDecodedInAttributeValue() throws Exception {
+        // characterization: numeric character references always decode, even in attribute context
+        final Document doc = parse("<a href=\"a&#38;b\">x</a>");
+        assertEquals("a&b", first(doc, "//A").getAttribute("href"));
+    }
+
+    @Test
+    public void namedEntityWithSemicolonDecodesInAttribute() throws Exception {
+        // characterization: once a trailing ';' is present, the attribute-context suppression rule
+        // does not apply and the named entity decodes normally
+        final Document doc = parse("<a href=\"?x=1&copy;2\">x</a>");
+        assertTrue(first(doc, "//A").getAttribute("href").contains("©2"));
+    }
+
+    @Test
+    public void namedEntityWithoutSemicolonDecodesWhenFollowedByNonAlnum() throws Exception {
+        // characterization: the attribute suppression rule only triggers when the char right after
+        // the entity name is alnum or '='; a following space still lets it decode
+        final Document doc = parse("<a title=\"x &copy y\">x</a>");
+        assertTrue(first(doc, "//A").getAttribute("title").contains("©"));
+    }
+
+    @Test
+    public void unterminatedSingleQuoteAttributeValueKeepsLeadingQuote() throws Exception {
+        // characterization: same fallback as double quotes, but for a single quote character
+        final Document doc = parse("<a href='x>");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("'x", a.getAttribute("href"));
+    }
+
+    @Test
+    public void leadingHyphenOnAttributeNameIsDroppedAndNextLetterStartsName() throws Exception {
+        // characterization: an attribute "name" cannot start with '-'; the parser resyncs on the next
+        // letter, so "-foo=\"bar\"" is parsed as attribute "foo" with value "bar"
+        final Document doc = parse("<div -foo=\"bar\">x</div>");
+        final Element div = first(doc, "//DIV");
+        assertFalse(div.hasAttribute("-foo"));
+        assertEquals("bar", div.getAttribute("foo"));
+    }
+
+    @Test
+    public void greaterThanInsideSingleQuotedValueEndsTagEarly() throws Exception {
+        // characterization: mirrors the double-quote case; the tag ends at the first raw '>' regardless
+        // of the (single) quote character, leaking the remainder as text
+        final Document doc = parse("<a title='x>y'>");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("'x", a.getAttribute("title"));
+        assertTrue(firstText(doc, "//HTML").contains("y'>"));
+    }
+
+    @Test
+    public void mixedSingleAndDoubleQuotesOnDifferentAttributes() throws Exception {
+        final Document doc = parse("<div id='a' class=\"b\">x</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("a", div.getAttribute("id"));
+        assertEquals("b", div.getAttribute("class"));
+    }
+
+    @Test
+    public void manyAttributeAssignmentsAllParsedInOrder() throws Exception {
+        final Document doc = parse("<a b=1 c=2 d=3 e=4>x</a>");
+        final Element a = first(doc, "//A");
+        assertEquals("1", a.getAttribute("b"));
+        assertEquals("2", a.getAttribute("c"));
+        assertEquals("3", a.getAttribute("d"));
+        assertEquals("4", a.getAttribute("e"));
+        assertEquals(4, a.getAttributes().getLength());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenChaoticCombosTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenChaoticCombosTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category N: chaotic / degenerate combination characterization tests. These lock in
+ * conservative "does not crash" and best-effort structural assertions for inputs that
+ * combine several kinds of breakage (unclosed + misnested + stray end tags, extreme
+ * sizes, control characters, etc.).
+ */
+public class BrokenChaoticCombosTest {
+
+    @Test
+    public void emptyInputProducesDocument() throws Exception {
+        // characterization: empty input never crashes and always yields a non-null Document
+        final Document doc = parse("");
+        assertNotNull(doc);
+    }
+
+    @Test
+    public void whitespaceOnlyInputDoesNotCrash() throws Exception {
+        final Document doc = parse("   ");
+        assertNotNull(doc);
+    }
+
+    @Test
+    public void newlineOnlyInputDoesNotCrash() throws Exception {
+        final Document doc = parse("\n\n");
+        assertNotNull(doc);
+    }
+
+    @Test
+    public void textOnlyInputProducesImplicitRoot() throws Exception {
+        // characterization: the scanner appends a trailing newline which bootstraps the implicit HTML root
+        final Document doc = parse("just text");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//HTML"));
+        assertTrue(firstText(doc, "//HTML").contains("just text"));
+    }
+
+    @Test
+    public void unclosedMisnestedAndStrayEndTagCombo() throws Exception {
+        // characterization: unclosed + misnested + stray-end-tag combination does not crash;
+        // key elements survive conservatively
+        final Document doc = parse("<div><b>x</p></i></div>");
+        assertNotNull(doc);
+        assertTrue(count(doc, "//DIV") >= 1);
+        assertTrue(count(doc, "//B") >= 1);
+    }
+
+    @Test
+    public void multipleCrossingTagsDoNotCrash() throws Exception {
+        // characterization: heavily crossing/interleaved tags parse without crashing
+        final Document doc = parse("<a><b><c></a></b></c>");
+        assertNotNull(doc);
+        assertTrue(count(doc, "//A") >= 1);
+    }
+
+    @Test
+    public void deeplyNestedDivsDoNotCrash() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append("<div>");
+        }
+        sb.append("deep");
+        final Document doc = parse(sb.toString());
+        assertNotNull(doc);
+        // characterization: current implementation nests every <div> instead of flattening
+        assertEquals(100, count(doc, "//DIV"));
+    }
+
+    @Test
+    public void hugeAttributeValueDoesNotCrash() throws Exception {
+        final StringBuilder sb = new StringBuilder("<div title=\"");
+        for (int i = 0; i < 10000; i++) {
+            sb.append('a');
+        }
+        sb.append("\">x</div>");
+        final Document doc = parse(sb.toString());
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(10000, first(doc, "//DIV").getAttribute("title").length());
+    }
+
+    @Test
+    public void controlCharactersMixedWithTextDoNotCrash() throws Exception {
+        // characterization: control characters (NUL, BEL) embedded in text do not crash the parser
+        final Document doc = parse("<p>a" + "\u0000" + "b" + "\u0007" + "c</p>");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains("a"));
+        assertTrue(firstText(doc, "//P").contains("c"));
+    }
+
+    @Test
+    public void legacyCenterAndFontComboDoesNotCrash() throws Exception {
+        final Document doc = parse("<center><font size=3>x</font></center>");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//CENTER"));
+        assertEquals(1, count(doc, "//CENTER/FONT"));
+        assertTrue(firstText(doc, "//FONT").contains("x"));
+    }
+
+    @Test
+    public void emptyTagSoupWithOnlyEndTagsDoesNotCrash() throws Exception {
+        // characterization: a document consisting solely of stray end tags does not crash
+        final Document doc = parse("</div></span></p>");
+        assertNotNull(doc);
+        assertEquals(0, count(doc, "//DIV"));
+        assertEquals(0, count(doc, "//SPAN"));
+        assertEquals(0, count(doc, "//P"));
+    }
+
+    @Test
+    public void manyConsecutiveSelfClosingVoidElementsDoNotCrash() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 500; i++) {
+            sb.append("<br/>");
+        }
+        final Document doc = parse(sb.toString());
+        assertNotNull(doc);
+        assertEquals(500, count(doc, "//BR"));
+    }
+
+    @Test
+    public void deeplyNestedMisnestedFormattingDoesNotCrash() throws Exception {
+        // characterization: combining deep nesting with misnested formatting tags is survivable
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 50; i++) {
+            sb.append("<b><i>");
+        }
+        sb.append("x");
+        final Document doc = parse(sb.toString());
+        assertNotNull(doc);
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(count(doc, "//I") >= 1);
+    }
+
+    @Test
+    public void mixedBrokenAttributesAndTagsDoNotCrash() throws Exception {
+        // characterization: combined attribute-syntax breakage and tag breakage does not crash
+        final Document doc = parse("<a b=c d><div title=\"x>y\"><123>text");
+        assertNotNull(doc);
+        assertTrue(count(doc, "//A") >= 1);
+    }
+
+    @Test
+    public void nulCharacterOnlyInputDoesNotCrash() throws Exception {
+        final Document doc = parse("\u0000");
+        assertNotNull(doc);
+    }
+
+    @Test
+    public void combinedCommentAndUnclosedTagDoesNotCrash() throws Exception {
+        // characterization: an unterminated comment followed by an unclosed tag still parses conservatively
+        final Document doc = parse("<!-- unclosed<div><b>x");
+        assertNotNull(doc);
+        assertTrue(count(doc, "//DIV") >= 0);
+    }
+
+    @Test
+    public void repeatedNestingOfTableInsideInlineDoesNotCrash() throws Exception {
+        // characterization: chaotic mixing of table structure inside formatting elements survives
+        final Document doc = parse("<b><table><tr><i><td>x</i></td></tr></table></b>");
+        assertNotNull(doc);
+        assertTrue(count(doc, "//TABLE") >= 1);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenCommentDoctypeCdataTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenCommentDoctypeCdataTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for broken/malformed comments, DOCTYPE, CDATA and
+ * processing instructions (category I). These tests lock in the current
+ * regex-based dispatch behavior of {@code SimpleHTMLScanner}, including
+ * several intentionally non-standard behaviors and differences between the
+ * {@code DOMParser} (which wires up a lexical handler) and the plain
+ * {@code SAXParser} entry point used via {@code saxEvents}/{@code saxStartElements}
+ * (which does not).
+ */
+public class BrokenCommentDoctypeCdataTest {
+
+    @Test
+    public void normalCommentBecomesDomCommentNodeByDefault() throws Exception {
+        // characterization: DOMParser wires SAXToDOMHandler as the lexical handler,
+        // so a well-formed comment DOES appear as a DOM comment node by default
+        final Document doc = parse("<div><!-- comment --></div>");
+        assertEquals(1, count(doc, "//comment()"));
+        assertTrue(firstText(doc, "//comment()").contains("comment"));
+    }
+
+    @Test
+    public void commentNodeIsSiblingOfSurroundingText() throws Exception {
+        final Document doc = parse("<p>a<!--c-->b</p>");
+        assertEquals(1, count(doc, "//P/comment()"));
+        assertEquals("c", firstText(doc, "//comment()"));
+    }
+
+    @Test
+    public void unclosedCommentLeaksAsText() throws Exception {
+        // characterization: an unterminated comment never matches the COMMENT pattern;
+        // the leading '<' is dropped and the rest (including "!--") leaks as text
+        final Document doc = parse("<div><!-- unclosed</div>");
+        assertEquals(0, count(doc, "//comment()"));
+        assertEquals(1, count(doc, "//DIV"));
+        assertTrue(firstText(doc, "//DIV").contains("!--"));
+        assertTrue(firstText(doc, "//DIV").contains("unclosed"));
+    }
+
+    @Test
+    public void shortFormBangDashDashGreaterDoesNotMatchLeaksAsText() throws Exception {
+        // characterization: "<!-->" is too short to satisfy "<!--" + "-->" (needs "<!---->" minimum),
+        // so it does not match COMMENT and leaks as text
+        final Document doc = parse("<div><!--></div>");
+        assertEquals(0, count(doc, "//comment()"));
+        assertTrue(firstText(doc, "//DIV").contains("!-->"));
+    }
+
+    @Test
+    public void tooShortDashCommentLeaksAsText() throws Exception {
+        // characterization: "<!--->" (6 chars) is still one character short of matching; it leaks as text
+        final Document doc = parse("<!--->");
+        assertEquals(0, count(doc, "//comment()"));
+        assertEquals(1, count(doc, "//text()[contains(.,'!--->')]"));
+    }
+
+    @Test
+    public void emptyCommentProducesEmptyCommentNode() throws Exception {
+        final Document doc = parse("<!---->");
+        assertEquals(1, count(doc, "//comment()"));
+        assertEquals("", firstText(doc, "//comment()"));
+    }
+
+    @Test
+    public void commentImmediatelyFollowedByTextOutsideIt() throws Exception {
+        final Document doc = parse("<!--x-->y");
+        assertEquals(1, count(doc, "//comment()"));
+        assertEquals("x", firstText(doc, "//comment()"));
+        assertEquals(1, count(doc, "//text()[contains(.,'y')]"));
+    }
+
+    @Test
+    public void nestedCommentMarkersAreAbsorbedIntoFirstComment() throws Exception {
+        // characterization: the non-greedy COMMENT regex closes at the FIRST "-->", so a nested
+        // "<!--" marker is swallowed as literal content of the outer comment, not parsed on its own
+        final Document doc = parse("<!-- <!-- -->");
+        assertEquals(1, count(doc, "//comment()"));
+        assertEquals("<!--", firstText(doc, "//comment()").trim());
+    }
+
+    @Test
+    public void doctypeDoesNotAppearInDom() throws Exception {
+        // characterization: <!DOCTYPE> is consumed by the scanner and never reaches the DOM
+        final Document doc = parse("<!DOCTYPE html><html><body>x</body></html>");
+        assertEquals(1, count(doc, "//BODY"));
+        assertTrue(firstText(doc, "//BODY").contains("x"));
+        assertEquals(0, count(doc, "//text()[contains(.,'DOCTYPE')]"));
+    }
+
+    @Test
+    public void lowercaseDoctypeKeywordWithUppercaseValueHandledNormally() throws Exception {
+        // characterization: the exact-case gate accepts a fully-lowercase "<!doctype" keyword,
+        // regardless of the case used in the doctype name itself
+        final Document doc = parse("<!doctype HTML><p>x</p>");
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P"));
+        assertEquals(0, count(doc, "//text()[contains(.,'doctype')]"));
+    }
+
+    @Test
+    public void mixedCaseDoctypeKeywordIsNotRecognizedAndLeaksAsText() throws Exception {
+        // characterization (gotcha): the scanner only special-cases the exact strings "<!DOCTYPE"
+        // and "<!doctype"; any other case mix (e.g. "<!DocType") fails that gate entirely and
+        // the whole construct leaks as text instead of being suppressed
+        final Document doc = parse("<!DocType html><p>x</p>");
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P"));
+        assertEquals(1, count(doc, "//text()[contains(.,'DocType')]"));
+    }
+
+    @Test
+    public void cdataEmitsInnerTextAsCharacters() throws Exception {
+        final Document doc = parse("<div><![CDATA[ text ]]></div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertTrue(firstText(doc, "//DIV").contains("text"));
+    }
+
+    @Test
+    public void cdataContentEntitiesAreNotDecoded() throws Exception {
+        // characterization: CDATA content is emitted verbatim (no resolveEntities call),
+        // unlike normal text content where "&amp;" would decode to "&"
+        final Document doc = parse("<div><![CDATA[ &amp; ]]></div>");
+        assertTrue(firstText(doc, "//DIV").contains("&amp;"));
+    }
+
+    @Test
+    public void unterminatedCdataDropsAngleBracketLeaksRestAsText() throws Exception {
+        // characterization: an unterminated CDATA section never matches; only the leading '<' is
+        // dropped and the rest (including "![CDATA[") leaks as text
+        final Document doc = parse("<div><![CDATA[ x</div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertTrue(firstText(doc, "//DIV").contains("![CDATA["));
+        assertTrue(firstText(doc, "//DIV").contains("x"));
+    }
+
+    @Test
+    public void xmlProcessingInstructionLeaksAsText() throws Exception {
+        // characterization: processing instructions are not recognized at all; '<' is dropped and
+        // "?xml ...?>" becomes ordinary text
+        final Document doc = parse("<?xml version=\"1.0\"?><p>x</p>");
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P"));
+        assertEquals(1, count(doc, "//text()[contains(.,'?xml')]"));
+    }
+
+    @Test
+    public void phpProcessingInstructionLeaksAsText() throws Exception {
+        final Document doc = parse("<?php echo 1 ?>");
+        assertEquals(1, count(doc, "//text()[contains(.,'php')]"));
+    }
+
+    @Test
+    public void entityDeclarationLeaksAsText() throws Exception {
+        // characterization: other "<!" constructs (e.g. <!ENTITY>) are not special-cased and leak as text
+        final Document doc = parse("<!ENTITY foo>");
+        assertEquals(1, count(doc, "//text()[contains(.,'ENTITY')]"));
+    }
+
+    @Test
+    public void saxCommentsAreSilentlyConsumedWithoutLexicalHandler() throws Exception {
+        // characterization: saxEvents() registers no lexical handler; the scanner still matches
+        // and consumes the comment (advancing past it) but never emits its content as characters,
+        // so the comment text disappears entirely (unlike CDATA, which always emits characters)
+        final List<String> events = saxEvents("<p>a<!--c-->b</p>");
+        assertTrue(events.contains("chars:a"));
+        assertTrue(events.contains("chars:b"));
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("chars:") && e.substring("chars:".length()).contains("c")));
+    }
+
+    @Test
+    public void saxStartElementsUnaffectedByComments() throws Exception {
+        // characterization: the tag balancer synthesizes an implicit HTML start element even
+        // though nothing about it is affected by the interleaved comment
+        final List<String> names = saxStartElements("<div><!--c--><p>x</p></div>");
+        assertEquals(List.of("HTML", "DIV", "P"), names);
+    }
+
+    @Test
+    public void doctypeConsumedSilentlyInSaxPathToo() throws Exception {
+        // characterization: unlike comments, DOCTYPE consumption does not depend on a lexical
+        // handler being present; it advances past the construct unconditionally
+        final List<String> events = saxEvents("<!DOCTYPE html><p>x</p>");
+        assertTrue(events.contains("start:P"));
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("chars:") && e.substring("chars:".length()).contains("DOCTYPE")));
+    }
+
+    @Test
+    public void cdataStillEmitsCharactersEvenWithoutLexicalHandlerViaSax() throws Exception {
+        // characterization: CDATA has an explicit fallback to emit characters when no lexical
+        // handler is set, unlike comments which are silently dropped in that case
+        final List<String> events = saxEvents("<![CDATA[ hi ]]>");
+        assertTrue(events.stream().anyMatch(e -> e.startsWith("chars:") && e.contains("hi")));
+    }
+
+    @Test
+    public void commentBetweenSiblingElementsDoesNotBreakTree() throws Exception {
+        final Document doc = parse("<ul><li>a</li><!-- x --><li>b</li></ul>");
+        assertEquals(2, count(doc, "//UL/LI"));
+        assertEquals(1, count(doc, "//comment()"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenEntitiesInParseTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenEntitiesInParseTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category K: HTML character entity resolution through the full parse path (DOMParser/SAXParser),
+ * as opposed to direct table lookups already covered by {@code HTMLEntitiesTest}.
+ *
+ * <p>
+ * characterization: entity resolution happens in {@code SimpleHTMLScanner#resolveEntities}, applied to
+ * every text run and (with different rules) every attribute value. The trailing semicolon is optional
+ * for both named and numeric references; invalid numeric code points become U+FFFD; and the "no
+ * semicolon + next char is alnum/'='" HTML5 attribute-value-state guard only applies to attribute
+ * values, not text.
+ * </p>
+ */
+public class BrokenEntitiesInParseTest {
+
+    @Test
+    public void unknownNamedEntityLeftVerbatim() throws Exception {
+        // characterization: unrecognized named entities are not decoded and are not even stripped of
+        // their trailing semicolon.
+        final Document doc = parse("<p>&foo;</p>");
+        assertTrue(firstText(doc, "//P").contains("&foo;"));
+    }
+
+    @Test
+    public void semicolonlessNamedEntityDecodesInText() throws Exception {
+        // characterization: the trailing ';' is optional for named entities in text.
+        final Document doc = parse("<p>&copy</p>");
+        assertTrue(firstText(doc, "//P").contains("©"));
+    }
+
+    @Test
+    public void semicolonlessStandardEntityAlsoDecodes() throws Exception {
+        final Document doc = parse("<p>a &amp b</p>");
+        assertTrue(firstText(doc, "//P").contains("a & b"));
+    }
+
+    @Test
+    public void standardEntitiesDecodeAmpLtGtQuot() throws Exception {
+        final Document doc = parse("<p>&amp;&lt;&gt;&quot;</p>");
+        assertTrue(firstText(doc, "//P").contains("&<>\""));
+    }
+
+    @Test
+    public void decimalNumericEntitiesDecode() throws Exception {
+        final Document doc = parse("<p>&#65;&#66;</p>");
+        assertTrue(firstText(doc, "//P").contains("AB"));
+    }
+
+    @Test
+    public void hexNumericEntitiesDecodeLowerAndUpperXMarker() throws Exception {
+        final Document doc = parse("<p>&#x41;&#X42;</p>");
+        assertTrue(firstText(doc, "//P").contains("AB"));
+    }
+
+    @Test
+    public void semicolonlessDecimalEntityStillDecodes() throws Exception {
+        // characterization: the ';' is optional for numeric references too.
+        final Document doc = parse("<p>&#65</p>");
+        assertTrue(firstText(doc, "//P").contains("A"));
+    }
+
+    @Test
+    public void nullCodePointBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#0;</p>");
+        assertTrue(firstText(doc, "//P").contains("�"));
+    }
+
+    @Test
+    public void surrogateCodePointBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#xD800;</p>");
+        assertTrue(firstText(doc, "//P").contains("�"));
+    }
+
+    @Test
+    public void noncharacterFfffCodePointBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#xFFFF;</p>");
+        assertTrue(firstText(doc, "//P").contains("�"));
+    }
+
+    @Test
+    public void controlCharacterNumericEntityBecomesReplacementChar() throws Exception {
+        // characterization: XML-illegal control characters (other than tab/LF/CR) become U+FFFD too.
+        final Document doc = parse("<p>&#1;</p>");
+        assertTrue(firstText(doc, "//P").contains("�"));
+    }
+
+    @Test
+    public void tabNewlineAndCarriageReturnNumericEntitiesArePreserved() throws Exception {
+        // characterization: tab/LF/CR are the control-character exceptions and decode normally.
+        final Document doc = parse("<p>a&#9;b&#10;c&#13;d</p>");
+        final String text = firstText(doc, "//P");
+        assertTrue(text.contains("a\tb"));
+        assertTrue(text.contains("b\nc") || text.contains("b\r\nc"));
+    }
+
+    @Test
+    public void nbspDecodesToNonBreakingSpace() throws Exception {
+        final Document doc = parse("<p>&nbsp;end</p>");
+        assertTrue(firstText(doc, "//P").contains(" end"));
+    }
+
+    @Test
+    public void supplementaryPlaneNumericEntityDecodesToSurrogatePair() throws Exception {
+        // U+1F600 GRINNING FACE - valid but outside the BMP.
+        final Document doc = parse("<p>&#128512;</p>");
+        final String text = firstText(doc, "//P");
+        assertTrue(text.contains(new String(Character.toChars(0x1F600))));
+    }
+
+    @Test
+    public void outOfUnicodeRangeNumericEntityBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#1114112;</p>");
+        assertTrue(firstText(doc, "//P").contains("�"));
+    }
+
+    @Test
+    public void entityAtStartAndEndOfTextIsDecoded() throws Exception {
+        final Document doc = parse("<p>&lt;tag&gt;</p>");
+        assertTrue(firstText(doc, "//P").contains("<tag>"));
+    }
+
+    @Test
+    public void doubleAmpersandWithNoValidNameStaysLiteral() throws Exception {
+        // characterization: "&&" never matches the entity pattern (no digits/hex/name follow the
+        // first '&'), so both ampersands survive untouched.
+        final Document doc = parse("<p>&&</p>");
+        assertTrue(firstText(doc, "//P").contains("&&"));
+    }
+
+    @Test
+    public void trailingAmpersandAtEndOfInputIsPreserved() throws Exception {
+        final Document doc = parse("<p>text&</p>");
+        assertTrue(firstText(doc, "//P").contains("text&"));
+    }
+
+    @Test
+    public void invalidHexDigitsAfterHexMarkerStayLiteral() throws Exception {
+        // characterization: "&#xZZ;" has no valid hex digits, so the entity pattern never matches
+        // here and the whole sequence is left completely untouched.
+        final Document doc = parse("<p>&#xZZ;</p>");
+        assertTrue(firstText(doc, "//P").contains("&#xZZ;"));
+    }
+
+    @Test
+    public void adjacentEntitiesAreResolvedInSinglePassNotRecursively() throws Exception {
+        // characterization: "&amp;&amp;" decodes to "&&" in one pass; the resulting ampersands are
+        // never re-scanned/re-decoded.
+        final Document doc = parse("<p>&amp;&amp;</p>");
+        assertTrue(firstText(doc, "//P").contains("&&"));
+    }
+
+    @Test
+    public void multipleConsecutiveMixedEntityFormsAllDecode() throws Exception {
+        final Document doc = parse("<p>&amp;&#65;&copy;</p>");
+        assertTrue(firstText(doc, "//P").contains("&A©"));
+    }
+
+    @Test
+    public void plainTextOutsideAnyElementIsAlsoEntityDecoded() throws Exception {
+        // characterization: entity resolution runs on every text run regardless of the surrounding
+        // element (or lack of one); here the implicit HTML root still gets decoded text.
+        final Document doc = parse("Hello &amp; world");
+        assertTrue(firstText(doc, "//HTML").contains("Hello & world"));
+    }
+
+    @Test
+    public void attributeAmpCopyEqualsPreservedVerbatim() throws Exception {
+        // characterization: HTML5 attribute-value-state guard - semicolon-less named entity followed
+        // by '=' is left untouched in an attribute value (protects URLs like "?x=1&copy=2").
+        final Document doc = parse("<a href=\"?x=1&copy=2\">x</a>");
+        assertTrue(first(doc, "//A").getAttribute("href").contains("&copy=2"));
+    }
+
+    @Test
+    public void textAmpCopyEqualsIsDecodedUnlikeAttribute() throws Exception {
+        // characterization: the same semicolon-less "&copy=" sequence in TEXT (not an attribute value)
+        // decodes normally, since the attribute-only guard does not apply there.
+        final Document doc = parse("<p>a&copy=2 b</p>");
+        assertTrue(firstText(doc, "//P").contains("a©=2 b"));
+    }
+
+    @Test
+    public void saxCharactersEventCarriesDecodedEntityText() throws Exception {
+        final List<String> events = saxEvents("<p>&amp;</p>");
+        assertTrue(events.stream().anyMatch(e -> e.startsWith("chars:") && e.contains("&")));
+    }
+
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlConfigModesTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlConfigModesTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codelibs.nekohtml.sax.HTMLSAXConfiguration;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Category O: config-dependent characterization tests. Covers the {@code nekohtml.dom.strict}
+ * system property (unset / "false" / "true"), the {@code balance-tags} feature, and lexical
+ * handler wiring on the public {@code DOMParser}/{@code SAXParser} API.
+ *
+ * <p>
+ * {@code nekohtml.dom.strict} is a GLOBAL system property; every test that touches it saves and
+ * restores the previous value in a {@code finally} block.
+ * </p>
+ */
+public class BrokenHtmlConfigModesTest {
+
+    private static final String PROPERTY_DOM_STRICT = "nekohtml.dom.strict";
+
+    private static final String LEXICAL_HANDLER_PROPERTY = "http://xml.org/sax/properties/lexical-handler";
+
+    // =========================================================================
+    // nekohtml.dom.strict: unset (default) mode
+    // =========================================================================
+
+    @Test
+    public void defaultModeDoesNotThrowOnUnclosedTags() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.clearProperty(PROPERTY_DOM_STRICT);
+            // characterization: default (unset) mode never throws for unclosed tags
+            assertDoesNotThrow(() -> parse("<div><p>a<span>b"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void defaultModeDoesNotThrowOnMismatchedTags() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.clearProperty(PROPERTY_DOM_STRICT);
+            // characterization: default (unset) mode never throws for misnested formatting tags
+            assertDoesNotThrow(() -> parse("<b><i>x</b></i>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    // =========================================================================
+    // nekohtml.dom.strict: explicit "false" (warning-level) mode
+    // =========================================================================
+
+    @Test
+    public void explicitFalseModeDoesNotThrowOnStrayEndTag() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "false");
+            // characterization: explicit "false" mode logs at WARNING level but never throws
+            assertDoesNotThrow(() -> parse("<div>a</span>b</div>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void explicitFalseModeDoesNotThrowOnMismatchedTags() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "false");
+            assertDoesNotThrow(() -> parse("<div><span></div></span>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    // =========================================================================
+    // nekohtml.dom.strict: "true" (strict) mode
+    // =========================================================================
+
+    @Test
+    public void strictModeDoesNotThrowOnWellFormedHtml() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertDoesNotThrow(() -> assertNotNull(parse("<html><body><p>ok</p></body></html>")));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void strictModeDoesNotThrowOnUnclosedTagsHandledByBalancer() throws Exception {
+        // characterization: the tag balancer normalizes unclosed tags into well-formed SAX events
+        // before they ever reach SAXToDOMHandler, so strict mode does not throw here either
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertDoesNotThrow(() -> parse("<div><p>a<span>b"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void strictModeDoesNotThrowOnMismatchedFormattingTagsHandledByBalancer() throws Exception {
+        // characterization: the Adoption Agency Algorithm resolves misnested formatting tags before
+        // the DOM builder sees them, so strict mode does not throw
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertDoesNotThrow(() -> parse("<b><i>x</b></i>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void strictModeDoesNotThrowOnStrayEndTagHandledByBalancer() throws Exception {
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertDoesNotThrow(() -> parse("</b>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void strictModeThrowsOnSecondTopLevelHtmlRoot() throws Exception {
+        // characterization: once the balancer's implicit-HTML tracking flag has already fired and
+        // the DOM element stack has unwound back to the Document node, a second top-level <html>
+        // tries to append a second document-element child and Document rejects it. In strict mode
+        // that DOM hierarchy violation is propagated as a SAXException.
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertThrows(SAXException.class, () -> parse("<html>a</html><html>b</html>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    @Test
+    public void strictModeThrowsOnElementAfterHtmlRootFullyClosed() throws Exception {
+        // characterization: same DOM hierarchy violation as above, triggered by any element (not
+        // just another <html>) arriving after the root has already fully closed
+        final String prev = System.getProperty(PROPERTY_DOM_STRICT);
+        try {
+            System.setProperty(PROPERTY_DOM_STRICT, "true");
+            assertThrows(SAXException.class, () -> parse("<html></html><p>x</p>"));
+        } finally {
+            restoreProperty(prev);
+        }
+    }
+
+    // =========================================================================
+    // balance-tags feature: settable on the public DOMParser/SAXParser
+    // =========================================================================
+
+    @Test
+    public void balanceTagsFeatureSettableOnPublicSaxParser() throws Exception {
+        final SAXParser parser = new SAXParser();
+        // characterization: the public SAXParser exposes setFeature/getFeature for balance-tags
+        assertTrue(parser.getFeature(HTMLSAXConfiguration.BALANCE_TAGS));
+        parser.setFeature(HTMLSAXConfiguration.BALANCE_TAGS, false);
+        assertFalse(parser.getFeature(HTMLSAXConfiguration.BALANCE_TAGS));
+    }
+
+    @Test
+    public void balanceTagsFeatureSettableOnPublicDomParser() throws Exception {
+        final DOMParser parser = new DOMParser();
+        assertTrue(parser.getFeature(HTMLSAXConfiguration.BALANCE_TAGS));
+        parser.setFeature(HTMLSAXConfiguration.BALANCE_TAGS, false);
+        assertFalse(parser.getFeature(HTMLSAXConfiguration.BALANCE_TAGS));
+    }
+
+    @Test
+    public void balanceTagsOffChangesConsecutiveParagraphEventStream() throws Exception {
+        // With balancing ON (default helper), consecutive <p> nest: start P, start P, end P, end P
+        final List<String> balanced = saxEvents("<p>a<p>b");
+
+        // With balancing OFF, the tag balancer filter is removed from the pipeline entirely, so no
+        // auto-closing/auto-nesting happens; raw scanner events pass straight through.
+        final SAXParser parser = new SAXParser();
+        parser.setFeature(HTMLSAXConfiguration.BALANCE_TAGS, false);
+        final List<String> unbalanced = collectEvents(parser, "<p>a<p>b");
+
+        // characterization: turning balance-tags off produces an observably different event stream
+        assertNotEquals(balanced, unbalanced);
+    }
+
+    @Test
+    public void balanceTagsOffSkipsImplicitHtmlRootInsertion() throws Exception {
+        // characterization: ensureDocumentInitialized() lives inside HTMLTagBalancerFilter, so with
+        // balance-tags off (filter removed from pipeline) no implicit HTML root is auto-inserted
+        final SAXParser parser = new SAXParser();
+        parser.setFeature(HTMLSAXConfiguration.BALANCE_TAGS, false);
+        final List<String> events = collectEvents(parser, "Hello<b>x</b>");
+        assertFalse(events.contains("start:HTML"));
+        assertTrue(events.contains("start:B"));
+    }
+
+    // =========================================================================
+    // Lexical handler wiring
+    // =========================================================================
+
+    @Test
+    public void defaultSaxParserHasNoLexicalHandlerSoCommentsAreSilentlyConsumed() throws Exception {
+        // characterization: a plain SAXParser with no registered lexical handler silently drops
+        // comment content; it never leaks into character events
+        final List<String> events = saxEvents("<p>a</p><!--secret--><p>b</p>");
+        assertFalse(events.stream().anyMatch(e -> e.contains("secret")));
+    }
+
+    @Test
+    public void customLexicalHandlerReceivesCommentEvents() throws Exception {
+        final SAXParser parser = new SAXParser();
+        final StringBuilder commentText = new StringBuilder();
+        parser.setProperty(LEXICAL_HANDLER_PROPERTY, new LexicalHandler() {
+            @Override
+            public void startDTD(final String name, final String publicId, final String systemId) {
+            }
+
+            @Override
+            public void endDTD() {
+            }
+
+            @Override
+            public void startEntity(final String name) {
+            }
+
+            @Override
+            public void endEntity(final String name) {
+            }
+
+            @Override
+            public void startCDATA() {
+            }
+
+            @Override
+            public void endCDATA() {
+            }
+
+            @Override
+            public void comment(final char[] ch, final int start, final int length) {
+                commentText.append(ch, start, length);
+            }
+        });
+        parser.setContentHandler(new DefaultHandler());
+        parser.parse(new InputSource(new StringReader("<!--hello-->")));
+
+        // characterization: registering a lexical handler via setProperty makes comment content observable
+        assertEquals("hello", commentText.toString());
+    }
+
+    @Test
+    public void domParserDefaultWiresLexicalHandlerProducingCommentNodes() throws Exception {
+        // characterization: DOMParser always wires its SAXToDOMHandler as the lexical handler, so
+        // comments become actual DOM Comment nodes (unlike a plain SAXParser)
+        final Document doc = parse("<p>a</p><!--hello--><p>b</p>");
+        assertEquals(1, count(doc, "//comment()"));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static void restoreProperty(final String prev) {
+        if (prev == null) {
+            System.clearProperty(PROPERTY_DOM_STRICT);
+        } else {
+            System.setProperty(PROPERTY_DOM_STRICT, prev);
+        }
+    }
+
+    /** Collects SAX startElement/endElement events (as "start:X"/"end:X") using a caller-supplied parser instance. */
+    private static List<String> collectEvents(final SAXParser parser, final String html) throws Exception {
+        final List<String> events = new ArrayList<>();
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
+                events.add("start:" + qName);
+            }
+
+            @Override
+            public void endElement(final String uri, final String localName, final String qName) {
+                events.add("end:" + qName);
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return events;
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlTestSupport.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlTestSupport.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Shared helper for broken-HTML characterization tests.
+ *
+ * <p>
+ * This helper depends only on the public {@code DOMParser}/{@code SAXParser}
+ * APIs and never touches the internal implementation. It exists purely to
+ * remove the boilerplate of building an {@code XPath} for every assertion.
+ * </p>
+ */
+public final class BrokenHtmlTestSupport {
+
+    private BrokenHtmlTestSupport() {
+    }
+
+    /** Parses the given HTML string with {@link DOMParser} and returns the Document. */
+    public static Document parse(final String html) throws Exception {
+        final DOMParser parser = new DOMParser();
+        parser.parse(new InputSource(new StringReader(html)));
+        return parser.getDocument();
+    }
+
+    /** Evaluates the XPath expression against the document and returns the node set. */
+    public static NodeList nodes(final Document doc, final String xpath) throws Exception {
+        final XPath xp = XPathFactory.newInstance().newXPath();
+        return (NodeList) xp.evaluate(xpath, doc, XPathConstants.NODESET);
+    }
+
+    /** Returns the number of nodes matching the XPath expression. */
+    public static int count(final Document doc, final String xpath) throws Exception {
+        return nodes(doc, xpath).getLength();
+    }
+
+    /** Returns the first element matching the XPath expression, or {@code null} if none. */
+    public static Element first(final Document doc, final String xpath) throws Exception {
+        final NodeList nl = nodes(doc, xpath);
+        return nl.getLength() == 0 ? null : (Element) nl.item(0);
+    }
+
+    /** Returns the text content of the first node matching the XPath, or {@code null} if none. */
+    public static String firstText(final Document doc, final String xpath) throws Exception {
+        final NodeList nl = nodes(doc, xpath);
+        return nl.getLength() == 0 ? null : nl.item(0).getTextContent();
+    }
+
+    /** Returns the SAX {@code startElement} qNames in document order. */
+    public static List<String> saxStartElements(final String html) throws Exception {
+        final List<String> names = new ArrayList<>();
+        final SAXParser parser = new SAXParser();
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
+                names.add(qName);
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return names;
+    }
+
+    /**
+     * Returns the SAX event stream as strings: {@code "start:X"}, {@code "end:X"} and
+     * {@code "chars:..."} in document order.
+     */
+    public static List<String> saxEvents(final String html) throws Exception {
+        final List<String> events = new ArrayList<>();
+        final SAXParser parser = new SAXParser();
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
+                events.add("start:" + qName);
+            }
+
+            @Override
+            public void endElement(final String uri, final String localName, final String qName) {
+                events.add("end:" + qName);
+            }
+
+            @Override
+            public void characters(final char[] ch, final int start, final int length) {
+                events.add("chars:" + new String(ch, start, length));
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return events;
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlTestSupportTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenHtmlTestSupportTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.saxEvents;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.saxStartElements;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Sanity tests for {@link BrokenHtmlTestSupport}.
+ */
+public class BrokenHtmlTestSupportTest {
+
+    @Test
+    public void parseReturnsDocument() throws Exception {
+        final Document doc = parse("<html><body><p>Hello</p></body></html>");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("Hello", firstText(doc, "//P"));
+        assertNotNull(first(doc, "//P"));
+        assertNull(first(doc, "//NOSUCH"));
+        assertEquals(0, count(doc, "//NOSUCH"));
+    }
+
+    @Test
+    public void saxStartElementsCollectsNames() throws Exception {
+        assertEquals(List.of("HTML", "BODY", "P"), saxStartElements("<html><body><p>x</p></body></html>"));
+    }
+
+    @Test
+    public void saxEventsIncludesStartEndChars() throws Exception {
+        final List<String> ev = saxEvents("<p>x</p>");
+        assertTrue(ev.contains("start:P"));
+        assertTrue(ev.contains("end:P"));
+        assertTrue(ev.stream().anyMatch(e -> e.startsWith("chars:")));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenImplicitStructureTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenImplicitStructureTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category M: implicit document structure characterization tests. Locks in the current
+ * behavior that only the HTML root is implicitly created; HEAD/BODY are never auto-generated.
+ */
+public class BrokenImplicitStructureTest {
+
+    @Test
+    public void onlyHtmlRootIsImplicitlyCreated() throws Exception {
+        // characterization: leading text triggers only an implicit HTML root; HEAD/BODY are never auto-created
+        final Document doc = parse("Hello<b>x</b>");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(0, count(doc, "//BODY"));
+        assertEquals(1, count(doc, "//B"));
+    }
+
+    @Test
+    public void leadingCommentCreatesHtmlRoot() throws Exception {
+        // characterization: a leading comment also bootstraps the implicit HTML root
+        final Document doc = parse("<!-- c --><p>x");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(1, count(doc, "//P"));
+        assertNotNull(firstText(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains("x"));
+    }
+
+    @Test
+    public void simpleBodyOnlyContentUnderHtmlRoot() throws Exception {
+        // characterization: bare body content sits directly under the implicit HTML root; no HEAD/BODY wrapper
+        final Document doc = parse("<p>x");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(0, count(doc, "//BODY"));
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains("x"));
+    }
+
+    @Test
+    public void bodyClosesOpenHeadAndTitle() throws Exception {
+        // characterization: an explicit BODY tag force-closes any still-open HEAD/TITLE
+        final Document doc = parse("<head><title>t</title><body>x");
+        assertEquals(1, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//BODY"));
+        assertEquals(1, count(doc, "//HEAD/TITLE"));
+        assertTrue(firstText(doc, "//TITLE").contains("t"));
+        assertTrue(firstText(doc, "//BODY").contains("x"));
+        // HEAD must not be an ancestor of BODY (it was closed before BODY opened)
+        assertEquals(0, count(doc, "//HEAD//BODY"));
+    }
+
+    @Test
+    public void framesetAlsoClosesOpenHeadAndTitle() throws Exception {
+        // characterization: FRAMESET behaves like BODY and force-closes HEAD/TITLE (BODY_ELEMENTS set)
+        final Document doc = parse("<head><title>t</title><frameset>x");
+        assertEquals(1, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//FRAMESET"));
+        assertEquals(1, count(doc, "//HEAD/TITLE"));
+        assertEquals(0, count(doc, "//HEAD//FRAMESET"));
+    }
+
+    @Test
+    public void titleThenTrailingTextGoesToHtmlDirectly() throws Exception {
+        // characterization: without an explicit HEAD wrapper, text following </title> becomes a
+        // direct child of the implicit HTML root (no HEAD/BODY exist at all)
+        final Document doc = parse("<title>t</title>x");
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(0, count(doc, "//BODY"));
+        assertEquals(1, count(doc, "//TITLE"));
+        assertTrue(firstText(doc, "//TITLE").contains("t"));
+        assertTrue(firstText(doc, "//HTML").contains("x"));
+    }
+
+    @Test
+    public void headElementsNotRelocatedIntoBody() throws Exception {
+        // characterization: head-ish elements (META/LINK) are left where they are; no implicit HEAD wrapper
+        final Document doc = parse("<meta charset=utf-8><p>x");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//META"));
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains("x"));
+    }
+
+    @Test
+    public void multipleVoidHeadElementsStayUnwrapped() throws Exception {
+        // characterization: several void head-ish elements in a row still get no implicit HEAD wrapper
+        final Document doc = parse("<meta a=1><link rel=x><p>y");
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//META"));
+        assertEquals(1, count(doc, "//LINK"));
+        assertEquals(1, count(doc, "//P"));
+    }
+
+    @Test
+    public void leadingTextThenHeadElementStillNoHeadWrapper() throws Exception {
+        // characterization: a head-ish element appearing after leading body text is not wrapped in HEAD either
+        final Document doc = parse("x<title>t</title>");
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//TITLE"));
+        assertTrue(firstText(doc, "//TITLE").contains("t"));
+    }
+
+    @Test
+    public void explicitHtmlDoesNotCreateSecondDocumentRoot() throws Exception {
+        // characterization: the DOM only ever has one document element even with a duplicated <html> tag
+        final Document doc = parse("<html><html>");
+        assertNotNull(doc.getDocumentElement());
+        assertEquals("HTML", doc.getDocumentElement().getNodeName());
+        assertEquals(1, count(doc, "/*"));
+    }
+
+    @Test
+    public void htmlRootAttributesArePreserved() throws Exception {
+        // characterization: the implicit-vs-explicit root distinction doesn't strip attributes on an explicit <html>
+        final Document doc = parse("<html lang=en><p>x</p></html>");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(0, count(doc, "//BODY"));
+        assertEquals("en", first(doc, "//HTML").getAttribute("lang"));
+    }
+
+    @Test
+    public void headWithoutBodyClosedAtEof() throws Exception {
+        // characterization: an unclosed HEAD/TITLE with no BODY at all is still closed (LIFO) at end-of-document
+        final Document doc = parse("<head><title>t</title>");
+        assertEquals(1, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//HEAD/TITLE"));
+        assertEquals(0, count(doc, "//BODY"));
+    }
+
+    @Test
+    public void commentInsideExplicitHtmlDoesNotDisruptStructure() throws Exception {
+        // characterization: a comment between HTML and BODY does not create a second root nor implicit HEAD
+        final Document doc = parse("<html><!-- c --><body>x</body></html>");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//BODY"));
+        assertTrue(firstText(doc, "//BODY").contains("x"));
+    }
+
+    @Test
+    public void bodyAfterExplicitCloseIsCharacterized() throws Exception {
+        // characterization: content appearing after </html> is recorded as-is (whatever the current parser does)
+        final Document doc = parse("<body>x</body><html>y</html>");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//BODY"));
+        assertTrue(count(doc, "//HTML") >= 1);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenListStructureTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenListStructureTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Characterization tests for broken/malformed list structures (category G).
+ * These tests lock in the current parsing behavior; some of it is
+ * intentionally non-standard compared to a real HTML5 parser.
+ */
+public class BrokenListStructureTest {
+
+    @Test
+    public void textBeforeLiStaysUnderUl() throws Exception {
+        // characterization: text preceding <li> inside <ul> stays as a UL child (not dropped)
+        final Document doc = parse("<ul>text<li>a</li></ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(1, count(doc, "//UL/LI"));
+        assertTrue(firstText(doc, "//UL").contains("text"));
+        assertEquals("a", firstText(doc, "//LI"));
+    }
+
+    @Test
+    public void nestedListsKeepBothULs() throws Exception {
+        // characterization: <ul><ul>... does not merge/complete li; both ULs are preserved
+        final Document doc = parse("<ul><ul><li>Item</li></ul></ul>");
+        assertEquals(2, count(doc, "//UL"));
+        assertEquals(1, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//UL/UL"));
+        assertEquals("Item", firstText(doc, "//LI"));
+    }
+
+    @Test
+    public void properlyClosedListItemsAreSiblings() throws Exception {
+        // control/contrast case: with explicit </li>, items are true siblings under UL
+        final Document doc = parse("<ul><li>a</li><li>b</li></ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(2, count(doc, "//UL/LI"));
+        assertEquals(0, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void unclosedListItemsNestInsteadOfSibling() throws Exception {
+        // characterization: without </li>, the second <li> nests inside the first (no sibling auto-close)
+        final Document doc = parse("<ul><li>a<li>b</ul>");
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//UL/LI"));
+        assertEquals(1, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void threeConsecutiveUnclosedLiFormChain() throws Exception {
+        // characterization: three consecutive unclosed <li> form a nesting chain, not three siblings
+        final Document doc = parse("<ul><li>a<li>b<li>c</ul>");
+        assertEquals(3, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//UL/LI"));
+        assertEquals(2, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void olWithSingleUnclosedLi() throws Exception {
+        // characterization: </ol> does not close the still-open <li> (mismatched end tag is ignored);
+        // the tree built so far (OL > LI) is kept regardless
+        final Document doc = parse("<ol><li>1</ol>");
+        assertEquals(1, count(doc, "//OL"));
+        assertEquals(1, count(doc, "//OL/LI"));
+        assertEquals("1", firstText(doc, "//LI"));
+    }
+
+    @Test
+    public void dlDtDdNestWithoutClosingTags() throws Exception {
+        // characterization: <dd> is not auto-completed as a sibling of the open <dt>; it nests inside it
+        final Document doc = parse("<dl><dt>t<dd>d</dl>");
+        assertEquals(1, count(doc, "//DL"));
+        assertEquals(1, count(doc, "//DL/DT"));
+        assertEquals(1, count(doc, "//DT/DD"));
+        assertTrue(firstText(doc, "//DT").contains("d"));
+    }
+
+    @Test
+    public void properlyClosedDlHasSiblingDtDd() throws Exception {
+        // control/contrast case: explicit closing tags produce true DT/DD siblings under DL
+        final Document doc = parse("<dl><dt>t1</dt><dd>d1</dd><dt>t2</dt><dd>d2</dd></dl>");
+        assertEquals(1, count(doc, "//DL"));
+        assertEquals(2, count(doc, "//DL/DT"));
+        assertEquals(2, count(doc, "//DL/DD"));
+        assertEquals(0, count(doc, "//DT/DD"));
+    }
+
+    @Test
+    public void orphanLiOutsideList() throws Exception {
+        // characterization: <li> with no <ul>/<ol> ancestor is still created (only HTML root is implicit)
+        final Document doc = parse("<li>orphan</li>");
+        assertEquals(1, count(doc, "//LI"));
+        assertEquals("orphan", firstText(doc, "//LI"));
+        assertEquals(0, count(doc, "//UL"));
+        assertEquals(0, count(doc, "//BODY"));
+    }
+
+    @Test
+    public void emptyUlHasNoChildren() throws Exception {
+        final Document doc = parse("<ul></ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(0, count(doc, "//UL/*"));
+    }
+
+    @Test
+    public void properlyNestedSubListInsideLi() throws Exception {
+        // control/contrast case: a properly nested sub-list (valid HTML) nests as expected
+        final Document doc = parse("<ul><li>a<ul><li>b</li></ul></li></ul>");
+        assertEquals(2, count(doc, "//UL"));
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//UL/LI/UL/LI"));
+    }
+
+    @Test
+    public void olClosedProperlyThreeSiblingLis() throws Exception {
+        final Document doc = parse("<ol><li>1</li><li>2</li><li>3</li></ol>");
+        assertEquals(1, count(doc, "//OL"));
+        assertEquals(3, count(doc, "//OL/LI"));
+        assertEquals(0, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void ulWithOnlyTextNoLi() throws Exception {
+        final Document doc = parse("<ul>just text</ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(0, count(doc, "//LI"));
+        assertTrue(firstText(doc, "//UL").contains("just text"));
+    }
+
+    @Test
+    public void nestedUlThreeLevelsDeep() throws Exception {
+        // characterization: repeated <ul> nesting (no li in between) stacks up three levels
+        final Document doc = parse("<ul><ul><ul><li>x</li></ul></ul></ul>");
+        assertEquals(3, count(doc, "//UL"));
+        assertEquals(1, count(doc, "//UL/UL/UL/LI"));
+        final Element outer = first(doc, "//UL");
+        assertNotNull(outer);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenMisnestedTagsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenMisnestedTagsTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Category B: misnested / mismatched tags.
+ *
+ * <p>
+ * These tests lock in the current (characterization) behavior of the Adoption Agency
+ * Algorithm (AAA) implementation for overlapping formatting elements, and the plain
+ * auto-close recovery for overlapping non-formatting (block) elements. The AAA final tree
+ * shape is intentionally asserted conservatively (presence/containment) since the exact
+ * reconstruction is an implementation detail; non-formatting mismatches are asserted more
+ * strictly where the current behavior is stable.
+ * </p>
+ */
+public class BrokenMisnestedTagsTest {
+
+    @Test
+    public void misnestedFormattingKeepsBothElements() throws Exception {
+        // characterization: <b><i>x</b></i> runs through AAA; both B and I survive in the tree
+        final Document doc = parse("<b><i>text</b></i>");
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(count(doc, "//I") >= 1);
+        assertTrue(firstText(doc, "//HTML").contains("text"));
+    }
+
+    @Test
+    public void mismatchedBlockRecovers() throws Exception {
+        // characterization: non-formatting mismatch </div></span> keeps DIV, drops the stray SPAN close
+        final Document doc = parse("<div><span></div></span>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//SPAN"));
+        assertEquals(1, count(doc, "//DIV/SPAN"));
+    }
+
+    @Test
+    public void crossingOverlapKeepsBothFormattingElements() throws Exception {
+        // characterization: <b><u>x</b>y</u> -- overlap resolved by AAA, both survive
+        final Document doc = parse("<b><u>x</b>y</u>");
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(count(doc, "//U") >= 1);
+        assertTrue(firstText(doc, "//HTML").contains("x"));
+        assertTrue(firstText(doc, "//HTML").contains("y"));
+    }
+
+    @Test
+    public void emStrongOverlapKeepsBothElements() throws Exception {
+        final Document doc = parse("<em><strong>a</em>b</strong>");
+        assertTrue(count(doc, "//EM") >= 1);
+        assertTrue(count(doc, "//STRONG") >= 1);
+        assertTrue(firstText(doc, "//HTML").contains("a"));
+        assertTrue(firstText(doc, "//HTML").contains("b"));
+    }
+
+    @Test
+    public void blockEndTagCrossingInlineFormattingKeepsBoth() throws Exception {
+        // characterization: </p> closing while <b> is still open triggers standard auto-close,
+        // not AAA (P is not a formatting element), so B ends up closed inside P.
+        final Document doc = parse("<p><b>bold</p></b>");
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(firstText(doc, "//P").contains("bold"));
+    }
+
+    @Test
+    public void anchorFormattingCrossKeepsBothElements() throws Exception {
+        // characterization: A is treated as a formatting element for AAA purposes
+        final Document doc = parse("<a><b>x</a>y</b>");
+        assertTrue(count(doc, "//A") >= 1);
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(firstText(doc, "//HTML").contains("x"));
+        assertTrue(firstText(doc, "//HTML").contains("y"));
+    }
+
+    @Test
+    public void fontColorAttributeSurvivesMisnesting() throws Exception {
+        final Document doc = parse("<font color=\"red\"><b>x</font>y</b>");
+        final Element font = first(doc, "//FONT");
+        assertNotNull(font);
+        assertEquals("red", font.getAttribute("color"));
+        assertTrue(count(doc, "//B") >= 1);
+    }
+
+    @Test
+    public void misnestedAndUnclosedCombination() throws Exception {
+        // characterization: misnesting plus an unclosed DIV -- all three elements still appear
+        final Document doc = parse("<div><b><i>deep</div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(count(doc, "//I") >= 1);
+        assertTrue(firstText(doc, "//DIV").contains("deep"));
+    }
+
+    @Test
+    public void sameFormattingElementNestedProperlyIsNotAAA() throws Exception {
+        // contrast case: properly-nested same-name formatting elements are NOT touched by AAA
+        final Document doc = parse("<i><i><i>x</i></i></i>");
+        assertEquals(3, count(doc, "//I"));
+        assertEquals(1, count(doc, "//I/I/I"));
+        assertEquals("x", firstText(doc, "//I/I/I").trim());
+    }
+
+    @Test
+    public void saxEventsForMisnestedFormattingAreLocked() throws Exception {
+        final List<String> events = saxEvents("<b><i>x</b></i>");
+        // characterization: exact SAX event sequence for the current AAA implementation
+        assertEquals(List.of("start:HTML", "start:B", "start:I", "chars:x", "end:I", "end:B", "start:I", "end:I", "end:HTML"), events
+                .stream().filter(e -> !e.equals("chars:\n")).toList());
+    }
+
+    @Test
+    public void divSpanCrossMismatchWithTextKeepsDiv() throws Exception {
+        final Document doc = parse("<div>a<span>b</div>c</span>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//SPAN"));
+        assertTrue(firstText(doc, "//DIV").contains("a"));
+        assertTrue(firstText(doc, "//DIV").contains("b"));
+    }
+
+    @Test
+    public void listItemCrossingFormattingElementKeepsBoth() throws Exception {
+        final Document doc = parse("<ul><li><b>x<li>y</b></ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(2, count(doc, "//LI"));
+        assertTrue(count(doc, "//B") >= 1);
+    }
+
+    @Test
+    public void headingCrossingFormattingElementKeepsBoth() throws Exception {
+        final Document doc = parse("<h1><b>Head</h1>Text</b>");
+        assertEquals(1, count(doc, "//H1"));
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(firstText(doc, "//H1").contains("Head"));
+    }
+
+    @Test
+    public void blockquoteCrossingFormattingElementKeepsBoth() throws Exception {
+        final Document doc = parse("<blockquote><i>Quote</blockquote>End</i>");
+        assertEquals(1, count(doc, "//BLOCKQUOTE"));
+        assertTrue(count(doc, "//I") >= 1);
+        assertTrue(firstText(doc, "//BLOCKQUOTE").contains("Quote"));
+    }
+
+    @Test
+    public void strikeAndSCrossingKeepsBoth() throws Exception {
+        final Document doc = parse("<s><strike>x</s>y</strike>");
+        assertTrue(count(doc, "//S") >= 1);
+        assertTrue(count(doc, "//STRIKE") >= 1);
+        assertTrue(firstText(doc, "//HTML").contains("x"));
+        assertTrue(firstText(doc, "//HTML").contains("y"));
+    }
+
+    @Test
+    public void nobrCrossingBoldKeepsBoth() throws Exception {
+        final Document doc = parse("<nobr><b>x</nobr>y</b>");
+        assertTrue(count(doc, "//NOBR") >= 1);
+        assertTrue(count(doc, "//B") >= 1);
+    }
+
+    @Test
+    public void ttCodeCrossingKeepsBoth() throws Exception {
+        final Document doc = parse("<tt><code>x</tt>y</code>");
+        assertTrue(count(doc, "//TT") >= 1);
+        assertTrue(count(doc, "//CODE") >= 1);
+    }
+
+    @Test
+    public void smallBigCrossingKeepsBoth() throws Exception {
+        final Document doc = parse("<small><big>x</small>y</big>");
+        assertTrue(count(doc, "//SMALL") >= 1);
+        assertTrue(count(doc, "//BIG") >= 1);
+    }
+
+    @Test
+    public void threeLevelMisnestingKeepsAllThreeElements() throws Exception {
+        final Document doc = parse("<b><i><u>x</b>y</u>z</i>");
+        assertTrue(count(doc, "//B") >= 1);
+        assertTrue(count(doc, "//I") >= 1);
+        assertTrue(count(doc, "//U") >= 1);
+        final String bodyText = firstText(doc, "//HTML");
+        assertTrue(bodyText.contains("x"));
+        assertTrue(bodyText.contains("y"));
+        assertTrue(bodyText.contains("z"));
+    }
+
+    @Test
+    public void saxStartElementsOrderForOverlapIsLocked() throws Exception {
+        // characterization: no explicit <body> is given, and BODY is NOT auto-created
+        final List<String> starts = saxStartElements("<div><span></div></span>");
+        assertEquals(List.of("HTML", "DIV", "SPAN"), starts);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenRawTextElementsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenRawTextElementsTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category J: raw text elements (script/style/textarea/title/xmp/plaintext) characterization tests.
+ *
+ * <p>
+ * characterization: the current implementation has NO raw-text tokenizer mode at all. SimpleHTMLScanner
+ * scans the whole document with the same generic start-tag/end-tag/text regex loop regardless of the
+ * enclosing element, so content inside script/style/textarea/title/xmp/plaintext is entity-decoded
+ * (non-standard for script/style/xmp) and any '&lt;letter' sequence inside it is parsed as a real tag
+ * (non-standard for all of these elements, which are raw text or RCDATA in the HTML5 spec).
+ * </p>
+ */
+public class BrokenRawTextElementsTest {
+
+    // ------------------------------------------------------------------
+    // <script>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void scriptWithoutAngleBracketsIsPreservedVerbatim() throws Exception {
+        final Document doc = parse("<script>alert('x')</script>");
+        assertEquals(1, count(doc, "//SCRIPT"));
+        assertTrue(firstText(doc, "//SCRIPT").contains("alert('x')"));
+    }
+
+    @Test
+    public void scriptEntitiesAreDecodedNonStandard() throws Exception {
+        // characterization: current implementation decodes entities inside <script> (non-standard;
+        // real HTML5 script content is raw text and entities are never decoded).
+        final Document doc = parse("<script>a &amp; b</script>");
+        assertEquals(1, count(doc, "//SCRIPT"));
+        final String text = firstText(doc, "//SCRIPT");
+        assertNotNull(text);
+        assertTrue(text.contains("a & b"));
+    }
+
+    @Test
+    public void unterminatedScriptIsClosedAtEof() throws Exception {
+        final Document doc = parse("<script>foo");
+        assertEquals(1, count(doc, "//SCRIPT"));
+        assertTrue(firstText(doc, "//SCRIPT").contains("foo"));
+    }
+
+    @Test
+    public void scriptWithTagLikeContentCreatesRealChildElement() throws Exception {
+        // characterization (non-standard): since there is no raw-text mode, a '<div>' inside <script>
+        // is parsed as an actual child DIV element rather than remaining literal script text.
+        final Document doc = parse("<script>var x = '<div>not a tag</div>';</script>");
+        assertEquals(1, count(doc, "//SCRIPT"));
+        assertEquals(1, count(doc, "//SCRIPT/DIV"));
+        assertTrue(firstText(doc, "//SCRIPT/DIV").contains("not a tag"));
+        // the text before/after the bogus <div> remains as text of SCRIPT itself
+        final String scriptText = firstText(doc, "//SCRIPT");
+        assertTrue(scriptText.contains("var x = '"));
+    }
+
+    @Test
+    public void scriptWithNonTagLikeLessThanDropsTheAngleBracket() throws Exception {
+        // characterization: '<' not followed by a letter (here a digit) matches neither START_TAG nor
+        // END_TAG, so the scanner falls into the "unknown tag, skip character" branch and silently
+        // drops the lone '<'; the surrounding text merges without it.
+        final Document doc = parse("<script>if (x<5) foo();</script>");
+        assertEquals(1, count(doc, "//SCRIPT"));
+        assertEquals(0, count(doc, "//SCRIPT/*"));
+        final String text = firstText(doc, "//SCRIPT");
+        assertTrue(text.contains("if (x5) foo();"));
+    }
+
+    @Test
+    public void multipleScriptElementsEachKeepOwnContent() throws Exception {
+        final Document doc = parse("<script>a</script><script>b</script>");
+        assertEquals(2, count(doc, "//SCRIPT"));
+    }
+
+    // ------------------------------------------------------------------
+    // <style>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void styleWithoutAngleBracketsIsPreservedVerbatim() throws Exception {
+        final Document doc = parse("<style>.a{color:red}</style>");
+        assertEquals(1, count(doc, "//STYLE"));
+        assertTrue(firstText(doc, "//STYLE").contains(".a{color:red}"));
+    }
+
+    @Test
+    public void styleEntitiesAreDecodedNonStandard() throws Exception {
+        // characterization: same non-standard entity decoding applies to <style> content.
+        final Document doc = parse("<style>a &amp; b</style>");
+        assertEquals(1, count(doc, "//STYLE"));
+        assertTrue(firstText(doc, "//STYLE").contains("a & b"));
+    }
+
+    @Test
+    public void unterminatedStyleIsClosedAtEof() throws Exception {
+        final Document doc = parse("<style>foo");
+        assertEquals(1, count(doc, "//STYLE"));
+        assertTrue(firstText(doc, "//STYLE").contains("foo"));
+    }
+
+    // ------------------------------------------------------------------
+    // <textarea>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void textareaEntitiesAreDecoded() throws Exception {
+        final Document doc = parse("<textarea>a &amp; b</textarea>");
+        assertEquals(1, count(doc, "//TEXTAREA"));
+        assertTrue(firstText(doc, "//TEXTAREA").contains("a & b"));
+    }
+
+    @Test
+    public void textareaWithTagLikeContentCreatesRealChildElement() throws Exception {
+        // characterization (non-standard): <p> inside <textarea> becomes a real child P element
+        // instead of literal RCDATA text.
+        final Document doc = parse("<textarea><p>This is not a paragraph</p></textarea>");
+        assertEquals(1, count(doc, "//TEXTAREA"));
+        assertEquals(1, count(doc, "//TEXTAREA/P"));
+        assertTrue(firstText(doc, "//TEXTAREA/P").contains("This is not a paragraph"));
+    }
+
+    // ------------------------------------------------------------------
+    // <title>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void titleEntitiesAreDecoded() throws Exception {
+        final Document doc = parse("<title>a &amp; b</title>");
+        assertEquals(1, count(doc, "//TITLE"));
+        assertTrue(firstText(doc, "//TITLE").contains("a & b"));
+    }
+
+    @Test
+    public void unterminatedTitleIsClosedAtEof() throws Exception {
+        final Document doc = parse("<title>abc");
+        assertEquals(1, count(doc, "//TITLE"));
+        assertTrue(firstText(doc, "//TITLE").contains("abc"));
+    }
+
+    // ------------------------------------------------------------------
+    // <xmp>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void xmpEntitiesAreDecodedNonStandard() throws Exception {
+        // characterization: real <xmp> is raw text (no entity decoding); current implementation
+        // decodes entities like everywhere else.
+        final Document doc = parse("<xmp>a &amp; b</xmp>");
+        assertEquals(1, count(doc, "//XMP"));
+        assertTrue(firstText(doc, "//XMP").contains("a & b"));
+    }
+
+    @Test
+    public void xmpWithTagLikeContentCreatesRealChildElement() throws Exception {
+        // characterization (non-standard): <b> inside <xmp> becomes a real child B element instead of
+        // literal text ("This is not bold" should never actually become bold per the HTML5 spec).
+        final Document doc = parse("<xmp><b>This is not bold</b></xmp>");
+        assertEquals(1, count(doc, "//XMP"));
+        assertEquals(1, count(doc, "//XMP/B"));
+        assertTrue(firstText(doc, "//XMP/B").contains("This is not bold"));
+    }
+
+    // ------------------------------------------------------------------
+    // <plaintext>
+    // ------------------------------------------------------------------
+
+    @Test
+    public void unterminatedPlaintextConsumesRestOfDocumentAsText() throws Exception {
+        // characterization: <plaintext> has no explicit end tag in HTML5 (rest of document is raw
+        // text); here it is just a normal element left open on the stack and closed at EOF like any
+        // other unclosed element.
+        final Document doc = parse("<plaintext>rest");
+        assertEquals(1, count(doc, "//PLAINTEXT"));
+        assertTrue(firstText(doc, "//PLAINTEXT").contains("rest"));
+    }
+
+    @Test
+    public void plaintextWithTagLikeContentCreatesRealChildElement() throws Exception {
+        // characterization (non-standard): a real <p> tag appearing after <plaintext> is parsed as an
+        // actual child element rather than being treated as literal text (real plaintext turns
+        // everything after it, including "<p>", into inert text for the rest of the document).
+        final Document doc = parse("<plaintext>rest<p>x</p>");
+        assertEquals(1, count(doc, "//PLAINTEXT"));
+        assertEquals(1, count(doc, "//PLAINTEXT/P"));
+        assertTrue(firstText(doc, "//PLAINTEXT/P").contains("x"));
+    }
+
+    // ------------------------------------------------------------------
+    // SAX event-level checks
+    // ------------------------------------------------------------------
+
+    @Test
+    public void saxEventsShowScriptEntityDecodedAsCharacters() throws Exception {
+        final List<String> events = saxEvents("<script>a &amp; b</script>");
+        assertTrue(events.contains("start:SCRIPT"));
+        assertTrue(events.contains("end:SCRIPT"));
+        assertTrue(events.stream().anyMatch(e -> e.startsWith("chars:") && e.contains("a & b")));
+    }
+
+    @Test
+    public void saxEventsShowTagLikeScriptContentAsNestedElement() throws Exception {
+        // characterization: the SAX stream for a bogus tag inside <script> shows a genuine
+        // start/end pair for the nested element rather than a single chars event for the whole script.
+        // Also locks in that an implicit HTML root wraps the fragment, auto-closed at EOF.
+        final List<String> events = saxEvents("<script>x<div>y</div>z</script>");
+        assertEquals("start:HTML", events.get(0));
+        assertEquals(List.of("start:SCRIPT", "chars:x", "start:DIV", "chars:y", "end:DIV", "chars:z", "end:SCRIPT"), events.subList(1, 8));
+        assertEquals("end:HTML", events.get(events.size() - 1));
+    }
+
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenSiblingAutoCloseTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenSiblingAutoCloseTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for the "no sibling auto-close" quirk (category D).
+ *
+ * <p>
+ * {@code HTMLTagBalancerFilter} tracks open elements on a single generic stack and only
+ * closes elements by exact tag-name match (see {@code endElement}). The element-metadata
+ * tables ({@code HEAD_ELEMENTS}, {@code GENERIC_CONTAINERS}) are never consulted, so there is
+ * no HTML5-style "starting this tag implicitly closes an open sibling of the same/related
+ * kind" behavior. Consecutive same-kind (or paragraph/heading-vs-block) tags therefore NEST
+ * instead of becoming siblings. This is a strong, intentional current quirk of NekoHTML 3.x.
+ * </p>
+ */
+public class BrokenSiblingAutoCloseTest {
+
+    @Test
+    public void consecutiveParagraphsNestInsteadOfSibling() throws Exception {
+        // characterization: current behavior (non-standard) - <p>a<p>b nests P inside P
+        // rather than closing the first P when the second starts.
+        final Document doc = parse("<p>a<p>b");
+        assertEquals(2, count(doc, "//P"));
+        assertEquals(1, count(doc, "//P/P"));
+    }
+
+    @Test
+    public void tripleConsecutiveParagraphsNestThreeDeep() throws Exception {
+        // characterization: current behavior (non-standard) - each new P nests one level
+        // deeper than the previous, forming a P > P > P chain.
+        final Document doc = parse("<p>a<p>b<p>c");
+        assertEquals(3, count(doc, "//P"));
+        assertEquals(2, count(doc, "//P/P"));
+        assertEquals(1, count(doc, "//P/P/P"));
+    }
+
+    @Test
+    public void consecutiveListItemsNestInsideUl() throws Exception {
+        // characterization: current behavior (non-standard) - <li> does not close a
+        // previous open <li>; the second LI nests inside the first.
+        final Document doc = parse("<ul><li>x<li>y</ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void consecutiveListItemsNestWithoutUlWrapper() throws Exception {
+        // characterization: current behavior (non-standard) - nesting happens even
+        // without a <ul> ancestor since there is no list-context tracking at all.
+        final Document doc = parse("<li>a<li>b");
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void tripleListItemsNestThreeDeep() throws Exception {
+        // characterization: current behavior (non-standard) - three consecutive <li>
+        // form a chain LI > LI > LI.
+        final Document doc = parse("<ol><li>1<li>2<li>3</ol>");
+        assertEquals(3, count(doc, "//LI"));
+        assertEquals(2, count(doc, "//LI/LI"));
+        assertEquals(1, count(doc, "//LI/LI/LI"));
+    }
+
+    @Test
+    public void dtFollowedByDdNests() throws Exception {
+        // characterization: current behavior (non-standard) - <dd> after an open <dt>
+        // nests DD inside DT instead of closing DT first.
+        final Document doc = parse("<dl><dt>a<dd>b</dl>");
+        assertEquals(1, count(doc, "//DL"));
+        assertEquals(1, count(doc, "//DT"));
+        assertEquals(1, count(doc, "//DD"));
+        assertEquals(1, count(doc, "//DT/DD"));
+    }
+
+    @Test
+    public void consecutiveDtElementsNest() throws Exception {
+        // characterization: current behavior (non-standard) - two consecutive <dt>
+        // nest rather than becoming siblings under <dl>.
+        final Document doc = parse("<dl><dt>a<dt>b</dl>");
+        assertEquals(2, count(doc, "//DT"));
+        assertEquals(1, count(doc, "//DT/DT"));
+    }
+
+    @Test
+    public void consecutiveOptionsNestInsideSelect() throws Exception {
+        // characterization: current behavior (non-standard) - SELECT/OPTION have no
+        // special-cased handling; the second OPTION nests inside the first.
+        final Document doc = parse("<select><option>a<option>b</select>");
+        assertEquals(1, count(doc, "//SELECT"));
+        assertEquals(2, count(doc, "//OPTION"));
+        assertEquals(1, count(doc, "//OPTION/OPTION"));
+    }
+
+    @Test
+    public void consecutiveOptionsNestWithoutSelectWrapper() throws Exception {
+        // characterization: current behavior (non-standard) - nesting occurs even
+        // without an enclosing <select>.
+        final Document doc = parse("<option>a<option>b");
+        assertEquals(2, count(doc, "//OPTION"));
+        assertEquals(1, count(doc, "//OPTION/OPTION"));
+    }
+
+    @Test
+    public void headingFollowedByDifferentHeadingNests() throws Exception {
+        // characterization: current behavior (non-standard) - <h1> then <h2> nests the
+        // H2 inside the open H1 (headings do not auto-close each other).
+        final Document doc = parse("<h1>a<h2>b");
+        assertEquals(1, count(doc, "//H1"));
+        assertEquals(1, count(doc, "//H2"));
+        assertEquals(1, count(doc, "//H1/H2"));
+    }
+
+    @Test
+    public void consecutiveSameHeadingsNest() throws Exception {
+        // characterization: current behavior (non-standard) - same-tag consecutive
+        // headings also nest, identical to the paragraph case.
+        final Document doc = parse("<h1>a<h1>b");
+        assertEquals(2, count(doc, "//H1"));
+        assertEquals(1, count(doc, "//H1/H1"));
+    }
+
+    @Test
+    public void trFollowedByTrNestsOutsideTableContext() throws Exception {
+        // characterization: current behavior (non-standard) - <tr><tr> with no table
+        // context at all still nests the second TR inside the first.
+        final Document doc = parse("<tr><tr>");
+        assertEquals(2, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TR/TR"));
+    }
+
+    @Test
+    public void consecutiveTdElementsNest() throws Exception {
+        // characterization: current behavior (non-standard) - a second <td> nests
+        // inside the still-open first <td> rather than closing it.
+        final Document doc = parse("<td>a<td>b");
+        assertEquals(2, count(doc, "//TD"));
+        assertEquals(1, count(doc, "//TD/TD"));
+    }
+
+    @Test
+    public void paragraphContainingBlockDivNests() throws Exception {
+        // characterization: current behavior (non-standard) - HTML5 requires <div>
+        // (a block element) to implicitly close an open <p>; NekoHTML 3.x does not
+        // implement this, so DIV nests inside the still-open P.
+        final Document doc = parse("<p>a<div>b");
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//P/DIV"));
+    }
+
+    @Test
+    public void listItemsAtEofCloseInLifoOrderPreservingNesting() throws Exception {
+        // characterization: current behavior (non-standard) - unclosed nested LIs are
+        // closed in LIFO order at EOF, keeping the nested parent/child structure intact.
+        final Document doc = parse("<ul><li>x<li>y");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//UL/LI"));
+        assertEquals(1, count(doc, "//UL/LI/LI"));
+    }
+
+    @Test
+    public void siblingParagraphsOnlyFormWhenExplicitlyClosed() throws Exception {
+        // characterization: explicitly closing the first <p> before the second starts
+        // is the only way to get true P siblings, confirming nesting (not the DOM
+        // sibling model) is what happens when the close tag is omitted.
+        final Document doc = parse("<p>a</p><p>b</p>");
+        assertEquals(2, count(doc, "//P"));
+        assertEquals(0, count(doc, "//P/P"));
+    }
+
+    @Test
+    public void saxEventsForConsecutiveParagraphsShowNestedStartsBeforeAnyEnd() throws Exception {
+        // characterization: current behavior (non-standard) - the SAX event stream shows
+        // both start:P events happening before either end:P, proving the second P is
+        // opened while the first is still open (i.e. nested), not sibling-replaced.
+        final List<String> events = saxEvents("<p>a<p>b");
+        final int firstStart = events.indexOf("start:P");
+        final int secondStart = events.subList(firstStart + 1, events.size()).indexOf("start:P") + firstStart + 1;
+        final int firstEnd = events.indexOf("end:P");
+        assertTrue(firstStart >= 0 && secondStart > firstStart);
+        assertTrue(firstEnd > secondStart);
+    }
+
+    @Test
+    public void consecutiveDdElementsNestWithoutDt() throws Exception {
+        // characterization: current behavior (non-standard) - <dd> elements nest even
+        // when there is no preceding <dt>.
+        final Document doc = parse("<dd>a<dd>b");
+        assertEquals(2, count(doc, "//DD"));
+        assertEquals(1, count(doc, "//DD/DD"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenStrayEndTagsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenStrayEndTagsTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category C: stray / orphan end tags.
+ *
+ * <p>
+ * These tests lock in the current (characterization) behavior when an end tag has no
+ * matching open start tag (or closes an element that isn't the current top of stack). The
+ * tag balancer passes such end tags straight through to the content handler, but the
+ * DOM-building layer ({@code SAXToDOMHandler}) only pops its own element stack when the tag
+ * name matches the currently open element -- so a stray end tag never produces or removes an
+ * element in the resulting DOM.
+ * </p>
+ */
+public class BrokenStrayEndTagsTest {
+
+    @Test
+    public void strayEndTagProducesNoElement() throws Exception {
+        // characterization: an </b> with no matching <b> is ignored by the DOM layer
+        final Document doc = parse("</b>");
+        assertEquals(0, count(doc, "//B"));
+    }
+
+    @Test
+    public void strayEndDivWithTrailingText() throws Exception {
+        final Document doc = parse("</div>text");
+        assertEquals(0, count(doc, "//DIV"));
+        assertTrue(firstText(doc, "//HTML").contains("text"));
+    }
+
+    @Test
+    public void doubleEndTagIsIgnoredTheSecondTime() throws Exception {
+        // characterization: the first </p> closes P normally; the second is a stray extra end tag
+        final Document doc = parse("<p>x</p></p>");
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P").trim());
+    }
+
+    @Test
+    public void excessiveEndTagsCollapseToOneElement() throws Exception {
+        final Document doc = parse("<body>x</body></body></html>");
+        assertEquals(1, count(doc, "//BODY"));
+        assertTrue(firstText(doc, "//BODY").contains("x"));
+    }
+
+    @Test
+    public void strayEndTagForVoidBrProducesNoElement() throws Exception {
+        // characterization: </br> alone (no preceding <br>) never creates a BR element
+        final Document doc = parse("</br>");
+        assertEquals(0, count(doc, "//BR"));
+    }
+
+    @Test
+    public void strayEndTagForVoidImgProducesNoElement() throws Exception {
+        final Document doc = parse("</img>");
+        assertEquals(0, count(doc, "//IMG"));
+    }
+
+    @Test
+    public void strayEndTagForVoidHrProducesNoElement() throws Exception {
+        final Document doc = parse("</hr>");
+        assertEquals(0, count(doc, "//HR"));
+    }
+
+    @Test
+    public void strayEndTagBetweenTextFragmentsIsDropped() throws Exception {
+        final Document doc = parse("text</span>more");
+        assertEquals(0, count(doc, "//SPAN"));
+        final String text = firstText(doc, "//HTML");
+        assertTrue(text.contains("text"));
+        assertTrue(text.contains("more"));
+    }
+
+    @Test
+    public void innerMismatchedEndKeepsParent() throws Exception {
+        // characterization: an internal stray </span> is ignored; DIV and its text survive intact
+        final Document doc = parse("<div>a</span>b</div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(0, count(doc, "//SPAN"));
+        assertTrue(firstText(doc, "//DIV").contains("a"));
+        assertTrue(firstText(doc, "//DIV").contains("b"));
+    }
+
+    @Test
+    public void saxEventsStillReportStrayEndTagEvenThoughDomIgnoresIt() throws Exception {
+        // characterization: the tag balancer passes the stray end tag through at the SAX level,
+        // even though the DOM builder discards it -- the SAX event stream still records it.
+        final List<String> events = saxEvents("</b>");
+        assertTrue(events.contains("end:B"));
+    }
+
+    @Test
+    public void saxEventsForInnerMismatchedEndAreLocked() throws Exception {
+        final List<String> events = saxEvents("<div>a</span>b</div>");
+        assertEquals(List.of("start:HTML", "start:DIV", "chars:a", "end:SPAN", "chars:b", "end:DIV", "end:HTML"),
+                events.stream().filter(e -> !e.equals("chars:\n")).toList());
+    }
+
+    @Test
+    public void strayEndTagFollowedByValidElementDoesNotAffectIt() throws Exception {
+        final Document doc = parse("</b><p>ok</p>");
+        assertEquals(0, count(doc, "//B"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("ok", firstText(doc, "//P").trim());
+    }
+
+    @Test
+    public void multipleStrayEndTagsInARowProduceNoElements() throws Exception {
+        final Document doc = parse("</b></i></u>");
+        assertEquals(0, count(doc, "//B"));
+        assertEquals(0, count(doc, "//I"));
+        assertEquals(0, count(doc, "//U"));
+    }
+
+    @Test
+    public void strayEndTagForUnknownElementDoesNotCrash() throws Exception {
+        final Document doc = parse("</foo>");
+        assertNotNull(doc);
+        assertEquals(0, count(doc, "//FOO"));
+    }
+
+    @Test
+    public void strayEndTagInsideValidStructureIsIgnored() throws Exception {
+        final Document doc = parse("<div><p>x</p></span></div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(0, count(doc, "//SPAN"));
+        assertEquals("x", firstText(doc, "//P").trim());
+    }
+
+    @Test
+    public void voidElementClosesOnStartAndExplicitEndTagIsStrayExtra() throws Exception {
+        // characterization: <br> auto-closes at the start tag itself; the following </br> is a
+        // separate, unmatched end tag and does not remove or duplicate the BR element.
+        final Document doc = parse("<div><br></br></div>");
+        assertEquals(1, count(doc, "//BR"));
+        assertEquals(0, count(doc, "//BR/*"));
+    }
+
+    @Test
+    public void saxEventsDoubleEndTagOnlyClosesOnce() throws Exception {
+        final List<String> events = saxEvents("<p>x</p></p>");
+        final long endPCount = events.stream().filter(e -> e.equals("end:P")).count();
+        // characterization: the balancer passes both end tags through at the SAX level (it has
+        // already popped P on the first one, so the second is "not on stack" and just forwarded)
+        assertEquals(2, endPCount);
+    }
+
+    @Test
+    public void strayEndTagAtVeryStartOfDocumentStillInitializesHtmlRoot() throws Exception {
+        // characterization: even though the stray end tag itself does not trigger HTML root
+        // creation, subsequent content does, and the HTML root is still created exactly once.
+        final Document doc = parse("</b>ok");
+        assertEquals(1, count(doc, "//HTML"));
+        assertTrue(firstText(doc, "//HTML").contains("ok"));
+    }
+
+    @Test
+    public void strayClosingTagForTableCellOutsideTableIsIgnored() throws Exception {
+        final Document doc = parse("</td>text");
+        assertEquals(0, count(doc, "//TD"));
+        assertTrue(firstText(doc, "//HTML").contains("text"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenTableStructureTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenTableStructureTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for broken table structures (category F).
+ *
+ * <p>
+ * {@code HTMLTagBalancerFilter} has no table-specific logic at all: {@code TABLE},
+ * {@code TBODY}, {@code THEAD}, {@code TFOOT}, {@code TR}, {@code TD}, {@code CAPTION} and
+ * {@code COLGROUP} are handled exactly like any other element on the single generic element
+ * stack. In particular there is no implicit {@code <tbody>} insertion, no requirement that
+ * {@code TR}/{@code TD} appear inside a table context, and no auto-closing between
+ * table-structure siblings (the same "no sibling auto-close" quirk as category D, applied
+ * here to table elements specifically). This class focuses on those gaps; well-formed table
+ * coverage already exists in {@code ComplexTableStructuresTest}.
+ * </p>
+ */
+public class BrokenTableStructureTest {
+
+    @Test
+    public void tableDoesNotInsertImplicitTbody() throws Exception {
+        // characterization: current behavior (non-standard) - no implicit <tbody> is
+        // inserted; TR is a direct child of TABLE.
+        final Document doc = parse("<table><tr><td>Cell</td></tr></table>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TD"));
+        assertEquals(0, count(doc, "//TBODY"));
+        assertEquals(1, count(doc, "//TABLE/TR"));
+        assertEquals("Cell", firstText(doc, "//TD"));
+    }
+
+    @Test
+    public void tdWithoutTrStaysDirectlyInTable() throws Exception {
+        // characterization: current behavior (non-standard) - TD is not forced into a
+        // TR/TBODY context; it becomes a direct child of TABLE.
+        final Document doc = parse("<table><td>x</td></table>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(0, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TD"));
+        assertEquals(1, count(doc, "//TABLE/TD"));
+    }
+
+    @Test
+    public void unclosedTrIsAutoClosedWhenTableCloses() throws Exception {
+        // characterization: TR left unclosed is auto-closed as part of the generic
+        // "close everything above the matched tag" logic when </table> is reached -
+        // this is ordinary stack unwinding, not table-specific behavior.
+        final Document doc = parse("<table><tr><td>a</td></table>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TABLE/TR"));
+        assertEquals(1, count(doc, "//TR/TD"));
+    }
+
+    @Test
+    public void tableWithBareTextDirectlyUnderTable() throws Exception {
+        // characterization: current behavior (non-standard) - free text directly
+        // inside <table> is kept as a text node child of TABLE (not relocated or
+        // dropped as browsers do with foster parenting).
+        final Document doc = parse("<table>text</table>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertTrue(firstText(doc, "//TABLE").contains("text"));
+    }
+
+    @Test
+    public void nestedTablesBothPresent() throws Exception {
+        final Document doc = parse("<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>");
+        assertEquals(2, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TABLE//TABLE"));
+        assertEquals("inner", firstText(doc, "//TABLE//TABLE//TD"));
+    }
+
+    @Test
+    public void threeLevelsOfNestedTablesAllPresent() throws Exception {
+        final Document doc =
+                parse("<table><tr><td><table><tr><td><table><tr><td>Deep</td></tr></table></td></tr></table></td></tr></table>");
+        assertEquals(3, count(doc, "//TABLE"));
+        assertEquals(2, count(doc, "//TABLE//TABLE"));
+        assertEquals(1, count(doc, "//TABLE//TABLE//TABLE"));
+        assertEquals("Deep", firstText(doc, "//TABLE//TABLE//TABLE//TD"));
+    }
+
+    @Test
+    public void tdStandaloneOutsideAnyTableIsStillParsed() throws Exception {
+        // characterization: current behavior (non-standard) - TD has no requirement
+        // of a TABLE ancestor; it is parsed as a normal element under the implicit
+        // HTML root.
+        final Document doc = parse("<td>x</td>");
+        assertEquals(1, count(doc, "//TD"));
+        assertEquals(0, count(doc, "//TABLE"));
+        assertEquals("x", firstText(doc, "//TD"));
+    }
+
+    @Test
+    public void trStandaloneOutsideAnyTableIsStillParsed() throws Exception {
+        final Document doc = parse("<tr><td>x</td></tr>");
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(0, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR/TD"));
+    }
+
+    @Test
+    public void captionBeforeTableStaysOutsideTable() throws Exception {
+        // characterization: current behavior (non-standard) - a CAPTION appearing
+        // before <table> is not relocated inside it; it remains a preceding sibling.
+        final Document doc = parse("<caption>Before</caption><table><tr><td>x</td></tr></table>");
+        assertEquals(1, count(doc, "//CAPTION"));
+        assertEquals(0, count(doc, "//TABLE/CAPTION"));
+        assertEquals(0, count(doc, "//TABLE//CAPTION"));
+    }
+
+    @Test
+    public void captionInsideTableIsChildOfTable() throws Exception {
+        final Document doc = parse("<table><caption>Cap</caption><tr><td>x</td></tr></table>");
+        assertEquals(1, count(doc, "//TABLE/CAPTION"));
+        assertEquals("Cap", firstText(doc, "//CAPTION"));
+    }
+
+    @Test
+    public void multipleCaptionsAreBothRetained() throws Exception {
+        // characterization: current behavior (non-standard) - a second <caption> is
+        // not rejected or merged; both are kept as children of TABLE (no sibling
+        // auto-close applies here either, but since CAPTION is closed explicitly each
+        // time, the two end up as true siblings rather than nested).
+        final Document doc = parse("<table><caption>C1</caption><caption>C2</caption><tr><td>x</td></tr></table>");
+        assertEquals(2, count(doc, "//TABLE/CAPTION"));
+        assertEquals(0, count(doc, "//CAPTION/CAPTION"));
+    }
+
+    @Test
+    public void explicitEmptyTbodyHasNoChildren() throws Exception {
+        final Document doc = parse("<table><tbody></tbody></table>");
+        assertEquals(1, count(doc, "//TBODY"));
+        assertEquals(0, count(doc, "//TBODY/*"));
+    }
+
+    @Test
+    public void consecutiveTdWithoutClosingNestInsideTr() throws Exception {
+        // characterization: current behavior (non-standard) - the same "no sibling
+        // auto-close" quirk (category D) applies inside a table row: a second <td>
+        // nests inside the still-open first <td> instead of becoming its sibling.
+        final Document doc = parse("<table><tr><td>a<td>b</tr></table>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(2, count(doc, "//TD"));
+        assertEquals(1, count(doc, "//TD/TD"));
+    }
+
+    @Test
+    public void tfootBeforeTbodyOrderIsPreservedNotReordered() throws Exception {
+        // characterization: current behavior (non-standard) - TFOOT appearing before
+        // TBODY in the source is not reordered to the canonical thead/tbody/tfoot
+        // order; document order is preserved.
+        final Document doc = parse("<table><tfoot><tr><td>f</td></tr></tfoot><tbody><tr><td>b</td></tr></tbody></table>");
+        assertEquals(1, count(doc, "//TFOOT"));
+        assertEquals(1, count(doc, "//TBODY"));
+        final List<String> children =
+                saxStartElements("<table><tfoot><tr><td>f</td></tr></tfoot><tbody><tr><td>b</td></tr></tbody></table>");
+        assertTrue(children.indexOf("TFOOT") < children.indexOf("TBODY"));
+    }
+
+    @Test
+    public void trOutsideAnyRowGroupIsNotWrappedInImplicitTbody() throws Exception {
+        // characterization: current behavior (non-standard) - a TR sibling of an
+        // explicit THEAD is left as a direct child of TABLE; it is not swept into an
+        // implicit TBODY the way a browser would.
+        final Document doc = parse("<table><thead><tr><th>h</th></tr></thead><tr><td>d</td></tr></table>");
+        assertEquals(0, count(doc, "//TBODY"));
+        assertEquals(2, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TABLE/TR"));
+    }
+
+    @Test
+    public void unclosedTbodyStaysOpenAcrossFollowingTheadNoAutoClose() throws Exception {
+        // characterization: current behavior (non-standard) - with no table-specific
+        // logic, an unclosed <tbody> is never implicitly closed by a following
+        // <thead>; THEAD instead nests inside the still-open TBODY.
+        final Document doc = parse("<table><tbody><tr><td>a</td></tr><thead><tr><th>h</th></tr></thead></table>");
+        assertEquals(1, count(doc, "//TBODY"));
+        assertEquals(1, count(doc, "//THEAD"));
+        assertEquals(1, count(doc, "//TBODY/THEAD"));
+        assertEquals(0, count(doc, "//TABLE/THEAD"));
+        assertEquals(1, count(doc, "//TBODY/TR"));
+    }
+
+    @Test
+    public void colgroupWithVoidColChildrenHasNoGrandchildren() throws Exception {
+        final Document doc = parse("<table><colgroup><col><col></colgroup><tr><td>x</td></tr></table>");
+        assertEquals(1, count(doc, "//COLGROUP"));
+        assertEquals(2, count(doc, "//COLGROUP/COL"));
+        assertEquals(0, count(doc, "//COL/*"));
+    }
+
+    @Test
+    public void colgroupStandaloneOutsideTableIsStillParsed() throws Exception {
+        final Document doc = parse("<colgroup><col></colgroup>");
+        assertEquals(0, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//COLGROUP"));
+        assertEquals(1, count(doc, "//COLGROUP/COL"));
+    }
+
+    @Test
+    public void saxEventsShowNoSyntheticTbodyEvents() throws Exception {
+        // characterization: SAX-level proof (not just the DOM projection) that no
+        // synthetic start:TBODY/end:TBODY events are ever emitted.
+        final List<String> events = saxStartElements("<table><tr><td>Cell</td></tr></table>");
+        assertFalse(events.contains("TBODY"));
+        assertEquals(List.of("HTML", "TABLE", "TR", "TD"), events);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenTagSyntaxTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenTagSyntaxTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Category L: malformed tag names/syntax characterization tests.
+ *
+ * <p>
+ * characterization: {@code SimpleHTMLScanner}'s start-tag pattern is
+ * {@code <([a-zA-Z][a-zA-Z0-9-:]*)([^>]*)>} - a tag name must start with a letter, and only
+ * letters/digits/'-'/':' may follow. Whenever '<' is not immediately followed by a valid tag-name
+ * start (and isn't part of a comment/DOCTYPE/CDATA/end-tag), the scanner falls into its "unknown tag"
+ * branch, which drops just that single '<' character and resumes plain-text scanning from the very
+ * next character - it never consumes or hides the rest of the bogus markup.
+ * </p>
+ */
+public class BrokenTagSyntaxTest {
+
+    // ------------------------------------------------------------------
+    // '<' not followed by a valid name start
+    // ------------------------------------------------------------------
+
+    @Test
+    public void bareAngleBracketsBecomeText() throws Exception {
+        // characterization: "<>" - '<' is dropped, ">" survives as text.
+        final Document doc = parse("<p><></p>");
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains(">"));
+    }
+
+    @Test
+    public void soleLessThanFollowedBySpaceBecomesText() throws Exception {
+        // characterization: "< >" - '<' is dropped, " >" survives as text.
+        final Document doc = parse("< >rest");
+        assertTrue(firstText(doc, "//HTML").contains(">rest"));
+    }
+
+    @Test
+    public void spaceThenLetterAfterLessThanIsNotATag() throws Exception {
+        // characterization: "< div>" - the space right after '<' disqualifies it as a tag start;
+        // '<' is dropped and "div>" survives as text (no DIV element is created).
+        final Document doc = parse("< div>rest");
+        assertEquals(0, count(doc, "//DIV"));
+        assertTrue(firstText(doc, "//HTML").contains("div>rest"));
+    }
+
+    @Test
+    public void digitStartedTagNameIsNotATag() throws Exception {
+        // characterization: "<123>" - a tag name may not start with a digit; '<' is dropped and
+        // "123>" survives as text.
+        final Document doc = parse("<p><123>text</p>");
+        assertTrue(firstText(doc, "//P").contains("123>text"));
+    }
+
+    @Test
+    public void hyphenStartedTagNameIsNotATag() throws Exception {
+        // characterization: "<-foo>" - a tag name may not start with '-'; '<' is dropped and
+        // "-foo>" survives as text.
+        final Document doc = parse("<p><-foo>text</p>");
+        assertTrue(firstText(doc, "//P").contains("-foo>text"));
+    }
+
+    @Test
+    public void tagNameCannotStartWithColon() throws Exception {
+        // characterization: ':' is allowed inside a tag name but not as its first character.
+        final Document doc = parse("<p><:tag>text</p>");
+        assertEquals(0, count(doc, "//*[local-name()='TAG']"));
+        assertTrue(firstText(doc, "//P").contains(":tag>text"));
+    }
+
+    @Test
+    public void consecutiveMalformedNumericTagsBecomeLiteralText() throws Exception {
+        // characterization: each bogus '<' is dropped independently; the surrounding fragments merge
+        // into one contiguous text run.
+        final Document doc = parse("<p><1><2><3></p>");
+        assertTrue(firstText(doc, "//P").contains("1>2>3>"));
+    }
+
+    // ------------------------------------------------------------------
+    // Unterminated tags (no closing '>' anywhere)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void unterminatedTagWithNoClosingAngleDropsLessThan() throws Exception {
+        // characterization: "<b" at EOF - START_TAG requires a literal '>', which never appears, so
+        // it can never match; '<' is dropped and "b" survives as text. No B element is created.
+        final Document doc = parse("<b");
+        assertEquals(0, count(doc, "//B"));
+        assertTrue(firstText(doc, "//HTML").contains("b"));
+    }
+
+    @Test
+    public void unterminatedTagWithAttributeLikeTextNoClosingAngle() throws Exception {
+        final Document doc = parse("<b attr");
+        assertEquals(0, count(doc, "//B"));
+        assertTrue(firstText(doc, "//HTML").contains("b attr"));
+    }
+
+    @Test
+    public void lessThanAtEndOfDocumentIsDroppedSilently() throws Exception {
+        // characterization: a single trailing '<' never becomes an element; but the scanner's line
+        // reader always appends a trailing '\n' to the raw content, and that lone newline is emitted
+        // as a characters() event, which is enough to bootstrap the implicit HTML root - so the
+        // document ends up with exactly one (empty) HTML element and nothing else.
+        final Document doc = parse("<");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//*"));
+        assertEquals(1, count(doc, "//HTML"));
+    }
+
+    // ------------------------------------------------------------------
+    // Valid-but-unusual tag names
+    // ------------------------------------------------------------------
+
+    @Test
+    public void hyphenatedTagNameUppercased() throws Exception {
+        final Document doc = parse("<my-tag>x</my-tag>");
+        assertEquals(1, count(doc, "//*[local-name()='MY-TAG']"));
+        assertTrue(firstText(doc, "//*[local-name()='MY-TAG']").contains("x"));
+    }
+
+    @Test
+    public void hyphenatedTagNameKeepsHyphenatedAttributeToo() throws Exception {
+        final Document doc = parse("<my-tag data-x=\"1\">x</my-tag>");
+        assertEquals("1", first(doc, "//*[local-name()='MY-TAG']").getAttribute("data-x"));
+    }
+
+    @Test
+    public void namespaceLikeColonTagNameIsPreserved() throws Exception {
+        // characterization: ':' is a legal tag-name character, so a namespace-looking name round-trips
+        // through a matching start/end tag pair like any ordinary element name. The element is created
+        // via the non-namespace-aware DOM API, so XPath's local-name() strips the "NS:" prefix down to
+        // just "TAG" (its localName is null); name() reports the full literal "NS:TAG" instead.
+        final Document doc = parse("<ns:tag>x</ns:tag>");
+        assertEquals(1, count(doc, "//*[name()='NS:TAG']"));
+        assertEquals(1, count(doc, "//*[local-name()='TAG']"));
+        assertTrue(firstText(doc, "//*[name()='NS:TAG']").contains("x"));
+    }
+
+    @Test
+    public void saxStartElementsShowNamespaceLikeTagVerbatim() throws Exception {
+        final List<String> starts = saxStartElements("<ns:tag>x</ns:tag>");
+        assertTrue(starts.contains("NS:TAG"));
+    }
+
+    @Test
+    public void tagNameMayContainDigitsAfterFirstLetter() throws Exception {
+        // characterization (contrast with digitStartedTagNameIsNotATag): a leading letter makes
+        // trailing digits perfectly legal in a tag name.
+        final Document doc = parse("<h1>x</h1>");
+        assertEquals(1, count(doc, "//H1"));
+        assertTrue(firstText(doc, "//H1").contains("x"));
+    }
+
+    @Test
+    public void underscoreInTagNameBreaksNameAtUnderscore() throws Exception {
+        // characterization: '_' is not a legal tag-name character, so the name group stops at "my"
+        // and "_tag" is left over to be (mis-)parsed as the attribute string.
+        final Document doc = parse("<my_tag>content");
+        assertEquals(1, count(doc, "//MY"));
+        assertTrue(firstText(doc, "//MY").contains("content"));
+    }
+
+    @Test
+    public void underscoreTagEndTagNeverMatchesRemainsOpenUntilEof() throws Exception {
+        // characterization: the corresponding "</my_tag>" fails the END_TAG pattern for the same
+        // reason (the underscore isn't a legal name character and no backtrack succeeds), so it is
+        // never recognized as a closing tag either; its '<' is dropped and the rest leaks as text
+        // inside the still-open MY element, which only gets closed implicitly at end of document.
+        final Document doc = parse("<my_tag>x</my_tag>");
+        assertEquals(1, count(doc, "//MY"));
+        final String text = firstText(doc, "//MY");
+        assertTrue(text.contains("x"));
+        assertTrue(text.contains("/my_tag>"));
+    }
+
+    // ------------------------------------------------------------------
+    // Multiple/odd '<' sequences
+    // ------------------------------------------------------------------
+
+    @Test
+    public void doubledOpenAngleDropsFirstThenParsesRealTag() throws Exception {
+        // characterization: "<<b>>" - the first '<' fails every check and is dropped; scanning then
+        // resumes at the second '<', which starts a perfectly valid "<b>" tag; the final ">" becomes
+        // B's text content.
+        final Document doc = parse("<<b>>");
+        assertEquals(1, count(doc, "//B"));
+        assertTrue(firstText(doc, "//B").contains(">"));
+    }
+
+    @Test
+    public void tripleAngleBracketsProduceNothing() throws Exception {
+        // characterization: "<<<" - every character is '<', so the scanner just drops each one in
+        // turn and never emits a characters() event for any of them. The only reason the document
+        // isn't completely empty is the scanner's line reader appending a trailing '\n', which is
+        // itself emitted as a characters() event and bootstraps the implicit HTML root.
+        final Document doc = parse("<<<");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//*"));
+        assertEquals(1, count(doc, "//HTML"));
+    }
+
+    @Test
+    public void mathLikeLessThanBetweenSpacesBecomesLiteralText() throws Exception {
+        // characterization: "a < b" - the '<' is not followed by a letter, so it is dropped; "a " and
+        // " b" merge into one text run around the gap left by the missing '<'.
+        final Document doc = parse("<p>a < b</p>");
+        final String text = firstText(doc, "//P");
+        assertTrue(text.contains("a"));
+        assertTrue(text.contains("b"));
+        assertTrue(text.contains("a  b") || text.contains("a b"));
+    }
+
+    // ------------------------------------------------------------------
+    // Self-closing slash and name resolution
+    // ------------------------------------------------------------------
+
+    @Test
+    public void selfClosingSlashDoesNotCorruptTagName() throws Exception {
+        // characterization: the trailing '/' is swallowed into the attribute-string group, not the
+        // tag name, so the element name still resolves cleanly to "B".
+        final Document doc = parse("<b/>x");
+        assertEquals(1, count(doc, "//B"));
+        assertTrue(firstText(doc, "//B").contains("x"));
+    }
+
+    @Test
+    public void saxEventsForDigitStartedTagShowNoElementJustText() throws Exception {
+        // characterization: only the implicit HTML root ever gets a start event; "<123>" never
+        // produces one of its own.
+        final List<String> events = saxEvents("<123>text");
+        final long startEventCount = events.stream().filter(e -> e.startsWith("start:")).count();
+        assertEquals(1, startEventCount);
+        assertEquals("start:HTML", events.get(0));
+        assertTrue(events.stream().anyMatch(e -> e.startsWith("chars:") && e.contains("123>text")));
+    }
+
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenUnclosedTagsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenUnclosedTagsTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Category A: unclosed tags.
+ *
+ * <p>
+ * These tests lock in the current (characterization) behavior of the parser when tags are
+ * never explicitly closed. The current implementation closes unclosed elements in LIFO order
+ * at EOF, preserving parent/child nesting.
+ * </p>
+ */
+public class BrokenUnclosedTagsTest {
+
+    @Test
+    public void singleUnclosedInlineClosedAtEof() throws Exception {
+        // characterization: a single unclosed <b> is closed at EOF
+        final Document doc = parse("<b>text");
+        assertEquals(1, count(doc, "//B"));
+        assertEquals("text", firstText(doc, "//B").trim());
+    }
+
+    @Test
+    public void nestedUnclosedAllPresent() throws Exception {
+        // characterization: unclosed tags are closed at EOF in LIFO order, preserving nesting
+        final Document doc = parse("<html><body><div><p>Text<span>More");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(1, count(doc, "//SPAN"));
+        assertEquals(1, count(doc, "//DIV/P"));
+        assertEquals(1, count(doc, "//P/SPAN"));
+        assertTrue(firstText(doc, "//SPAN").contains("More"));
+    }
+
+    @Test
+    public void pUnclosedInsideDivClosedByDivEnd() throws Exception {
+        // characterization: <p> without a closing tag is swallowed when the ancestor </div> arrives
+        final Document doc = parse("<div><p>a</div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(1, count(doc, "//DIV/P"));
+        assertEquals("a", firstText(doc, "//P").trim());
+    }
+
+    @Test
+    public void inlineMultipleUnclosedEofReverseOrder() throws Exception {
+        // characterization: nested unclosed inline elements close in reverse (LIFO) order at EOF
+        final Document doc = parse("<i>a<b>b");
+        assertEquals(1, count(doc, "//I"));
+        assertEquals(1, count(doc, "//B"));
+        assertEquals(1, count(doc, "//I/B"));
+        assertEquals("b", firstText(doc, "//B").trim());
+    }
+
+    @Test
+    public void unclosedListItemsNestInsteadOfSibling() throws Exception {
+        // characterization: NO sibling auto-close (dead metadata) -- consecutive unclosed <li>
+        // elements nest rather than becoming siblings.
+        final Document doc = parse("<ul><li>a<li>b");
+        assertEquals(2, count(doc, "//LI"));
+        assertEquals(1, count(doc, "//LI/LI"));
+    }
+
+    @Test
+    public void unclosedTitleInHead() throws Exception {
+        final Document doc = parse("<title>abc");
+        assertEquals(1, count(doc, "//TITLE"));
+        assertEquals("abc", firstText(doc, "//TITLE").trim());
+    }
+
+    @Test
+    public void unclosedAnchorWithAttribute() throws Exception {
+        final Document doc = parse("<a href=\"x\">link");
+        final Element a = first(doc, "//A");
+        assertNotNull(a);
+        assertEquals("x", a.getAttribute("href"));
+        assertEquals("link", firstText(doc, "//A").trim());
+    }
+
+    @Test
+    public void deepUnclosedSameElementNests() throws Exception {
+        // characterization: same-named unclosed elements keep nesting (no implicit close)
+        final Document doc = parse("<div><div><div>deep");
+        assertEquals(3, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//DIV/DIV/DIV"));
+        assertTrue(firstText(doc, "//DIV/DIV/DIV").contains("deep"));
+    }
+
+    @Test
+    public void tableUnclosedElementsNestAndDoNotCloseAtEof() throws Exception {
+        // characterization: unclosed table structure closes at EOF, preserving nesting; no implicit tbody
+        final Document doc = parse("<table><tr><td>cell");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TD"));
+        assertEquals(0, count(doc, "//TBODY"));
+        assertEquals(1, count(doc, "//TABLE/TR/TD"));
+        assertEquals("cell", firstText(doc, "//TD").trim());
+    }
+
+    @Test
+    public void saxEndEventFiresAtEofForUnclosedElement() throws Exception {
+        final List<String> events = saxEvents("<b>x");
+        assertTrue(events.contains("end:B"));
+        // characterization: the implicit HTML root is auto-closed at EOF too, after B
+        assertEquals(List.of("start:HTML", "start:B", "end:B", "end:HTML"), events.stream().filter(e -> !e.startsWith("chars:")).toList());
+    }
+
+    @Test
+    public void tripleUnclosedSameInlineElementNests() throws Exception {
+        final Document doc = parse("<span>a<span>b<span>c");
+        assertEquals(3, count(doc, "//SPAN"));
+        assertEquals(1, count(doc, "//SPAN/SPAN/SPAN"));
+        assertTrue(firstText(doc, "//SPAN/SPAN/SPAN").contains("c"));
+    }
+
+    @Test
+    public void unclosedListItemsClosedByAncestorEnd() throws Exception {
+        // characterization: an explicit </ul> auto-closes any still-open <li> elements above it
+        final Document doc = parse("<ul><li>a<li>b<li>c</ul>");
+        assertEquals(1, count(doc, "//UL"));
+        assertEquals(3, count(doc, "//LI"));
+        // characterization: unclosed LIs nest rather than becoming UL's direct siblings
+        assertEquals(1, count(doc, "//UL/LI"));
+        assertEquals(1, count(doc, "//UL/LI/LI"));
+        assertEquals(1, count(doc, "//UL/LI/LI/LI"));
+    }
+
+    @Test
+    public void multiLevelUnclosedClosedBySingleAncestorEndTag() throws Exception {
+        // characterization: a single </div> auto-closes every unclosed descendant in one shot
+        final Document doc = parse("<div><p>Text<span>More</div>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(1, count(doc, "//SPAN"));
+        assertEquals(1, count(doc, "//DIV/P/SPAN"));
+    }
+
+    @Test
+    public void blockAndInlineMixedUnclosedNestsThreeDeep() throws Exception {
+        final Document doc = parse("<blockquote><p>a<b>b");
+        assertEquals(1, count(doc, "//BLOCKQUOTE"));
+        assertEquals(1, count(doc, "//P"));
+        assertEquals(1, count(doc, "//B"));
+        assertEquals(1, count(doc, "//BLOCKQUOTE/P/B"));
+        assertEquals("b", firstText(doc, "//B").trim());
+    }
+
+    @Test
+    public void unclosedTitleUnderExplicitHead() throws Exception {
+        final Document doc = parse("<html><head><title>t");
+        assertEquals(1, count(doc, "//HEAD"));
+        assertEquals(1, count(doc, "//TITLE"));
+        assertEquals(1, count(doc, "//HEAD/TITLE"));
+        assertEquals("t", firstText(doc, "//TITLE").trim());
+    }
+
+    @Test
+    public void saxEventOrderForUnclosedNestedIsLifoAtEof() throws Exception {
+        final List<String> events = saxEvents("<div><p>a<span>b");
+        // characterization: end events fire in reverse-open order once EOF is reached
+        final int endDiv = events.lastIndexOf("end:DIV");
+        final int endP = events.lastIndexOf("end:P");
+        final int endSpan = events.lastIndexOf("end:SPAN");
+        assertTrue(endSpan < endP, "SPAN should close before P");
+        assertTrue(endP < endDiv, "P should close before DIV");
+    }
+
+    @Test
+    public void attributesArePreservedAcrossAutoCloseAtEof() throws Exception {
+        final Document doc = parse("<div id=\"d1\"><p class=\"c1\">Text");
+        final Element div = first(doc, "//DIV");
+        final Element p = first(doc, "//P");
+        assertNotNull(div);
+        assertNotNull(p);
+        assertEquals("d1", div.getAttribute("id"));
+        assertEquals("c1", p.getAttribute("class"));
+    }
+
+    @Test
+    public void unclosedDtDdNestRatherThanSibling() throws Exception {
+        // characterization: no sibling auto-close for DD/DT either -- DD nests inside DT
+        final Document doc = parse("<dl><dt>a<dd>b");
+        assertEquals(1, count(doc, "//DL"));
+        assertEquals(1, count(doc, "//DT"));
+        assertEquals(1, count(doc, "//DD"));
+        assertEquals(1, count(doc, "//DT/DD"));
+    }
+
+    @Test
+    public void unclosedFormattingElementInsideUnclosedBlock() throws Exception {
+        final Document doc = parse("<div><em>text");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//EM"));
+        assertEquals(1, count(doc, "//DIV/EM"));
+    }
+
+    @Test
+    public void unclosedTableRowWithoutCellClosesAtEof() throws Exception {
+        final Document doc = parse("<table><tr>");
+        assertEquals(1, count(doc, "//TABLE"));
+        assertEquals(1, count(doc, "//TR"));
+        assertEquals(1, count(doc, "//TABLE/TR"));
+        assertEquals(0, count(doc, "//TD"));
+    }
+
+    @Test
+    public void unclosedNestedTableStructurePreservesAllLevels() throws Exception {
+        final Document doc = parse("<table><tr><td><table><tr><td>inner");
+        assertEquals(2, count(doc, "//TABLE"));
+        assertEquals(2, count(doc, "//TR"));
+        assertEquals(2, count(doc, "//TD"));
+        assertEquals(1, count(doc, "//TABLE/TR/TD/TABLE/TR/TD"));
+        assertTrue(firstText(doc, "//TABLE/TR/TD/TABLE/TR/TD").contains("inner"));
+    }
+
+    @Test
+    public void unclosedHeadingElementClosedAtEof() throws Exception {
+        final Document doc = parse("<h1>Heading");
+        assertEquals(1, count(doc, "//H1"));
+        assertEquals("Heading", firstText(doc, "//H1").trim());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/BrokenVoidAndSelfClosingTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/BrokenVoidAndSelfClosingTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Characterization tests for void elements and self-closing syntax (category E).
+ *
+ * <p>
+ * {@code SimpleHTMLScanner} immediately emits a matching {@code endElement} right after
+ * {@code startElement} for the 13 HTML5 void elements (AREA, BASE, BR, COL, EMBED, HR, IMG,
+ * INPUT, LINK, META, PARAM, SOURCE, TRACK, WBR), so {@code HTMLTagBalancerFilter} never
+ * pushes them onto its element stack and they never contain children. A trailing
+ * {@code /} in a start tag (e.g. {@code <div/>}, {@code <br/>}) is not treated specially by
+ * the {@code START_TAG}/{@code ATTRIBUTE} regexes: it is simply discarded as unmatched
+ * attribute text. For non-void elements this means the self-closing syntax is silently
+ * ignored and the element remains open, wrapping whatever follows.
+ * </p>
+ */
+public class BrokenVoidAndSelfClosingTest {
+
+    @Test
+    public void brIsVoidAndNeverGetsChildren() throws Exception {
+        // characterization: current behavior - BR is emitted and immediately closed,
+        // never pushed onto the stack, so it can have no children.
+        final Document doc = parse("<div><br>text</div>");
+        assertEquals(1, count(doc, "//BR"));
+        assertEquals(0, count(doc, "//BR/*"));
+        assertTrue(firstText(doc, "//DIV").contains("text"));
+    }
+
+    @Test
+    public void hrIsVoid() throws Exception {
+        final Document doc = parse("<div><hr>text</div>");
+        assertEquals(1, count(doc, "//HR"));
+        assertEquals(0, count(doc, "//HR/*"));
+    }
+
+    @Test
+    public void imgIsVoidAndKeepsAttributes() throws Exception {
+        final Document doc = parse("<div><img src=x>text</div>");
+        assertEquals(1, count(doc, "//IMG"));
+        final Element img = first(doc, "//IMG");
+        assertEquals("x", img.getAttribute("src"));
+        assertEquals(0, count(doc, "//IMG/*"));
+    }
+
+    @Test
+    public void inputIsVoid() throws Exception {
+        final Document doc = parse("<div><input>text</div>");
+        assertEquals(1, count(doc, "//INPUT"));
+        assertEquals(0, count(doc, "//INPUT/*"));
+    }
+
+    @Test
+    public void metaIsVoid() throws Exception {
+        final Document doc = parse("<meta charset=utf-8><p>x</p>");
+        assertEquals(1, count(doc, "//META"));
+        assertEquals(0, count(doc, "//META/*"));
+    }
+
+    @Test
+    public void linkIsVoid() throws Exception {
+        final Document doc = parse("<link rel=stylesheet><p>x</p>");
+        assertEquals(1, count(doc, "//LINK"));
+        assertEquals(0, count(doc, "//LINK/*"));
+    }
+
+    @Test
+    public void wbrIsVoid() throws Exception {
+        final Document doc = parse("<p>a<wbr>b</p>");
+        assertEquals(1, count(doc, "//WBR"));
+        assertEquals(0, count(doc, "//WBR/*"));
+    }
+
+    @Test
+    public void colIsVoid() throws Exception {
+        final Document doc = parse("<colgroup><col></colgroup>");
+        assertEquals(1, count(doc, "//COL"));
+        assertEquals(0, count(doc, "//COL/*"));
+    }
+
+    @Test
+    public void embedIsVoid() throws Exception {
+        final Document doc = parse("<embed src=x>");
+        assertEquals(1, count(doc, "//EMBED"));
+        assertEquals(0, count(doc, "//EMBED/*"));
+    }
+
+    @Test
+    public void sourceIsVoid() throws Exception {
+        final Document doc = parse("<video><source src=x></video>");
+        assertEquals(1, count(doc, "//SOURCE"));
+        assertEquals(0, count(doc, "//SOURCE/*"));
+    }
+
+    @Test
+    public void trackIsVoid() throws Exception {
+        final Document doc = parse("<video><track kind=captions></video>");
+        assertEquals(1, count(doc, "//TRACK"));
+        assertEquals(0, count(doc, "//TRACK/*"));
+    }
+
+    @Test
+    public void baseIsVoid() throws Exception {
+        final Document doc = parse("<base href=x><p>y</p>");
+        assertEquals(1, count(doc, "//BASE"));
+        assertEquals(0, count(doc, "//BASE/*"));
+    }
+
+    @Test
+    public void paramIsVoid() throws Exception {
+        final Document doc = parse("<object><param name=x></object>");
+        assertEquals(1, count(doc, "//PARAM"));
+        assertEquals(0, count(doc, "//PARAM/*"));
+    }
+
+    @Test
+    public void areaIsVoid() throws Exception {
+        final Document doc = parse("<map><area shape=rect></map>");
+        assertEquals(1, count(doc, "//AREA"));
+        assertEquals(0, count(doc, "//AREA/*"));
+    }
+
+    @Test
+    public void selfClosingBrSlashIsStillVoidBr() throws Exception {
+        // characterization: <br/> parses as a normal void BR; the trailing '/' is
+        // discarded by attribute parsing and has no special effect (BR is already void).
+        final Document doc = parse("<br/>");
+        assertEquals(1, count(doc, "//BR"));
+    }
+
+    @Test
+    public void selfClosingBrWithSpaceSlashIsVoidBr() throws Exception {
+        final Document doc = parse("<br />");
+        assertEquals(1, count(doc, "//BR"));
+    }
+
+    @Test
+    public void selfClosingImgSlashKeepsAttributeAndIsVoid() throws Exception {
+        final Document doc = parse("<img src=\"x\"/>");
+        assertEquals(1, count(doc, "//IMG"));
+        assertEquals("x", first(doc, "//IMG").getAttribute("src"));
+    }
+
+    @Test
+    public void nonVoidSelfClosingDivIsIgnoredAndStaysOpen() throws Exception {
+        // characterization: current behavior (non-standard) - the '/' before '>' on a
+        // non-void element is discarded; DIV remains open and wraps the following SPAN.
+        final Document doc = parse("<div/><span>x</span>");
+        assertEquals(1, count(doc, "//DIV"));
+        assertEquals(1, count(doc, "//DIV//SPAN"));
+    }
+
+    @Test
+    public void nonVoidSelfClosingSpanWrapsFollowingText() throws Exception {
+        // characterization: current behavior (non-standard) - <span/>text keeps SPAN
+        // open, so the following text becomes a child of SPAN rather than a sibling.
+        final Document doc = parse("<span/>text");
+        assertEquals(1, count(doc, "//SPAN"));
+        assertTrue(firstText(doc, "//SPAN").contains("text"));
+    }
+
+    @Test
+    public void nonVoidSelfClosingPWrapsFollowingText() throws Exception {
+        // characterization: current behavior (non-standard) - <p/>x keeps P open and
+        // absorbs the following text as its content.
+        final Document doc = parse("<p/>x");
+        assertEquals(1, count(doc, "//P"));
+        assertTrue(firstText(doc, "//P").contains("x"));
+    }
+
+    @Test
+    public void unknownElementSelfClosingIsAlsoIgnored() throws Exception {
+        // characterization: current behavior (non-standard) - unknown tag names are not
+        // in VOID_ELEMENTS, so <foo/> behaves like any other non-void self-closing tag:
+        // it stays open and wraps whatever follows.
+        final Document doc = parse("<foo/>bar</foo>");
+        assertEquals(1, count(doc, "//*[local-name()='FOO']"));
+        assertTrue(firstText(doc, "//*[local-name()='FOO']").contains("bar"));
+    }
+
+    @Test
+    public void strayVoidEndTagBrIsHarmless() throws Exception {
+        // characterization: current behavior - </br> is a stray end tag for an element
+        // that was never pushed onto the stack (BR is void), so it is passed straight
+        // through by the balancer as an end event with no corresponding open element.
+        final Document doc = parse("<p>a</br>b</p>");
+        assertEquals(0, count(doc, "//BR"));
+        assertEquals(1, count(doc, "//P"));
+    }
+
+    @Test
+    public void consecutiveVoidImgElementsDoNotNest() throws Exception {
+        // characterization: since void elements are never pushed onto the stack, two
+        // consecutive <img> tags cannot nest (unlike non-void elements in category D);
+        // both are always siblings under the same parent.
+        final Document doc = parse("<div><img>text<img></div>");
+        assertEquals(2, count(doc, "//IMG"));
+        assertEquals(0, count(doc, "//IMG/IMG"));
+        assertEquals(2, count(doc, "//DIV/IMG"));
+    }
+
+    @Test
+    public void saxEventsForVoidBrShowImmediateEndBeforeFollowingText() throws Exception {
+        // characterization: SAX event order confirms end:BR fires immediately after
+        // start:BR, before the following characters event. The final event is the
+        // implicit HTML root being closed at EOF (no explicit <html> was given).
+        final List<String> events = saxEvents("<br>after");
+        final int startIdx = events.indexOf("start:BR");
+        final int endIdx = events.indexOf("end:BR");
+        assertTrue(startIdx >= 0);
+        assertEquals(startIdx + 1, endIdx);
+        assertEquals(List.of("start:HTML", "start:BR", "end:BR", "chars:after\n", "end:HTML"), events);
+    }
+
+    @Test
+    public void voidElementWithSelfClosingSlashHasNoChildrenEvenWithAttributes() throws Exception {
+        final Document doc = parse("<input type=\"text\" name=\"x\"/><p>after</p>");
+        assertEquals(1, count(doc, "//INPUT"));
+        final Element input = first(doc, "//INPUT");
+        assertEquals("text", input.getAttribute("type"));
+        assertEquals("x", input.getAttribute("name"));
+        assertEquals(0, count(doc, "//INPUT/*"));
+        assertEquals(1, count(doc, "//P"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidCommentCdataTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidCommentCdataTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.childSignature;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.lexicalEvents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for comments and CDATA sections on VALID/well-formed HTML, exercised
+ * through the SAX lexical-event stream ({@code lexicalEvents}) and through the DOM tree built by
+ * {@code DOMParser}.
+ */
+public class ValidCommentCdataTest {
+
+    // -----------------------------------------------------------------
+    // Comments
+    // -----------------------------------------------------------------
+
+    @Test
+    public void commentTextPreservesSurroundingWhitespace() throws Exception {
+        final List<String> events = lexicalEvents("<p>a</p><!-- hi --><p>b</p>");
+        // characterization: the space before/after "hi" is part of the captured comment text
+        assertTrue(events.contains("comment: hi "), events.toString());
+    }
+
+    @Test
+    public void commentAppearsAsDomCommentNodeWithExactValue() throws Exception {
+        final Document doc = parse("<p>a</p><!-- hi --><p>b</p>");
+        assertEquals(1, count(doc, "//comment()"));
+        final List<String> sig = childSignature(doc.getDocumentElement());
+        assertTrue(sig.contains("comment: hi "), sig.toString());
+    }
+
+    @Test
+    public void commentIsSiblingOfSurroundingTextNodesInOrder() throws Exception {
+        final Document doc = parse("<p>a<!--c-->b</p>");
+        final List<String> sig = childSignature(first(doc, "//P"));
+        assertEquals(List.of("text:a", "comment:c", "text:b"), sig);
+    }
+
+    @Test
+    public void entitiesAreNotDecodedInsideComments() throws Exception {
+        // characterization: comment content is captured verbatim; no entity resolution is applied
+        final List<String> events = lexicalEvents("<!--&amp;--><p>x</p>");
+        assertTrue(events.contains("comment:&amp;"), events.toString());
+    }
+
+    @Test
+    public void entitiesNotDecodedInsideCommentAlsoHoldsInDom() throws Exception {
+        final Document doc = parse("<!--&amp;--><p>x</p>");
+        // characterization: a comment that appears before any real element has been opened is
+        // attached directly to the Document node itself (a sibling of the auto-inserted HTML root),
+        // not nested inside the HTML subtree
+        assertEquals("&amp;", doc.getFirstChild().getNodeValue());
+    }
+
+    @Test
+    public void multiLineCommentPreservesEmbeddedNewline() throws Exception {
+        final List<String> events = lexicalEvents("<!--l1\nl2--><p>x</p>");
+        assertTrue(events.contains("comment:l1\nl2"), events.toString());
+    }
+
+    @Test
+    public void emptyCommentProducesEmptyCommentText() throws Exception {
+        final List<String> events = lexicalEvents("<!----><p>x</p>");
+        assertTrue(events.contains("comment:"), events.toString());
+    }
+
+    @Test
+    public void emptyCommentProducesEmptyDomCommentNode() throws Exception {
+        final Document doc = parse("<!----><p>x</p>");
+        assertEquals(1, count(doc, "//comment()"));
+        // characterization: same document-level attachment as above, since the comment precedes
+        // the first real element
+        assertEquals("", doc.getFirstChild().getNodeValue());
+    }
+
+    @Test
+    public void commentContainingMarkupIsNotParsedAsTags() throws Exception {
+        // characterization: text that looks like a tag inside a comment stays literal comment text
+        final List<String> events = lexicalEvents("<!-- <p>not a tag</p> --><p>x</p>");
+        assertTrue(events.contains("comment: <p>not a tag</p> "), events.toString());
+        // only the real <p>x</p> produces a start:P event
+        assertEquals(1, events.stream().filter(e -> e.equals("start:P")).count());
+    }
+
+    @Test
+    public void twoConsecutiveCommentsBothAppearInOrder() throws Exception {
+        final List<String> events = lexicalEvents("<!--first--><!--second--><p>x</p>");
+        assertTrue(events.indexOf("comment:first") < events.indexOf("comment:second"), events.toString());
+        assertTrue(events.indexOf("comment:second") < events.indexOf("start:P"), events.toString());
+    }
+
+    @Test
+    public void commentBetweenListItemsDoesNotBreakDomStructure() throws Exception {
+        final Document doc = parse("<ul><li>a</li><!-- x --><li>b</li></ul>");
+        assertEquals(2, count(doc, "//UL/LI"));
+        assertEquals(1, count(doc, "//comment()"));
+    }
+
+    // -----------------------------------------------------------------
+    // CDATA
+    // -----------------------------------------------------------------
+
+    @Test
+    public void cdataEmitsStartCdataCharsEndCdataInOrder() throws Exception {
+        final List<String> events = lexicalEvents("<div><![CDATA[x <b>raw</b> & y]]></div>");
+        assertTrue(events.contains("startCDATA"), events.toString());
+        assertTrue(events.contains("endCDATA"), events.toString());
+        // characterization: markup inside CDATA is not parsed, and '&' is not decoded
+        assertTrue(events.contains("chars:x <b>raw</b> & y"), events.toString());
+        final int startCdata = events.indexOf("startCDATA");
+        final int chars = events.indexOf("chars:x <b>raw</b> & y");
+        final int endCdata = events.indexOf("endCDATA");
+        assertTrue(startCdata < chars, events.toString());
+        assertTrue(chars < endCdata, events.toString());
+    }
+
+    @Test
+    public void cdataDoesNotProduceElementEventsForEmbeddedTags() throws Exception {
+        final List<String> events = lexicalEvents("<div><![CDATA[x <b>raw</b> & y]]></div>");
+        assertTrue(events.stream().noneMatch(e -> e.equals("start:B")), events.toString());
+    }
+
+    @Test
+    public void cdataAppearsAsPlainTextNodeInDomNotCdataSection() throws Exception {
+        final Document doc = parse("<div><![CDATA[abc]]></div>");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        // characterization: CDATA content is folded into a regular DOM Text node, not a CDATASection
+        assertEquals(List.of("text:abc"), sig);
+    }
+
+    @Test
+    public void emptyCdataEmitsNoCharsButStillEmitsStartAndEndCdata() throws Exception {
+        final List<String> events = lexicalEvents("<div><![CDATA[]]></div>");
+        assertTrue(events.contains("startCDATA"), events.toString());
+        assertTrue(events.contains("endCDATA"), events.toString());
+        final int startCdata = events.indexOf("startCDATA");
+        final int endCdata = events.indexOf("endCDATA");
+        // characterization: no "chars:" event is emitted for an empty CDATA section
+        assertEquals(startCdata + 1, endCdata, events.toString());
+    }
+
+    @Test
+    public void whitespaceOnlyCdataPreservedVerbatim() throws Exception {
+        final List<String> events = lexicalEvents("<div><![CDATA[   ]]></div>");
+        assertTrue(events.contains("chars:   "), events.toString());
+    }
+
+    @Test
+    public void cdataMergesWithSurroundingTextIntoSingleDomTextNode() throws Exception {
+        // characterization: the CDATA boundary is invisible to the DOM builder (startCDATA/endCDATA
+        // are no-ops there), so text before/inside/after a CDATA section merges into one Text node
+        final Document doc = parse("<div>a<![CDATA[b]]>c</div>");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        assertEquals(List.of("text:abc"), sig);
+    }
+
+    @Test
+    public void cdataEntitiesNotDecodedInDom() throws Exception {
+        final Document doc = parse("<div><![CDATA[&amp;]]></div>");
+        assertEquals("&amp;", first(doc, "//DIV").getTextContent());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidConfigNoOpGuardsTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidConfigNoOpGuardsTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.saxEvents;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.saxEventsWithFeature;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.saxQNameUriLocal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterization tests locking in which SAX features are actual NO-OPs (stored in the feature
+ * map but never consulted by {@code SimpleHTMLScanner}/the parsing pipeline for observable output)
+ * versus {@code balance-tags}, which is the only feature that demonstrably changes the SAX event
+ * stream.
+ *
+ * <p>
+ * This is a regression guard: if a future change wires one of the currently-inert features into
+ * the scanner, the corresponding "no-op" test below will start failing, which is the intended
+ * signal that the characterization needs to be revisited.
+ * </p>
+ */
+public class ValidConfigNoOpGuardsTest {
+
+    private static final String NAMESPACES = "http://xml.org/sax/features/namespaces";
+
+    private static final String AUGMENTATIONS = "http://cyberneko.org/html/features/augmentations";
+
+    private static final String REPORT_ERRORS = "http://cyberneko.org/html/features/report-errors";
+
+    private static final String SIMPLE_ERROR_FORMAT = "http://cyberneko.org/html/features/report-errors/simple-format";
+
+    private static final String BALANCE_TAGS = "http://cyberneko.org/html/features/balance-tags";
+
+    private static final String HTML5_MODE = "http://cyberneko.org/html/features/html5-mode";
+
+    private static final String WELL_FORMED_HTML = "<html><body><p>hi</p></body></html>";
+
+    private static final String HEADLESS_HTML = "<p>hi</p>";
+
+    private static final String ATTR_HTML = "<div id=\"a\">x</div>";
+
+    // =========================================================================
+    // NAMESPACES: no-op
+    // =========================================================================
+
+    @Test
+    public void namespacesTrueIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, NAMESPACES, true));
+    }
+
+    @Test
+    public void namespacesFalseIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, NAMESPACES, false));
+    }
+
+    @Test
+    public void namespacesTrueIsNoOpOnHeadlessHtml() throws Exception {
+        assertEquals(saxEvents(HEADLESS_HTML), saxEventsWithFeature(HEADLESS_HTML, NAMESPACES, true));
+    }
+
+    @Test
+    public void namespacesTrueIsNoOpOnHtmlWithAttributes() throws Exception {
+        assertEquals(saxEvents(ATTR_HTML), saxEventsWithFeature(ATTR_HTML, NAMESPACES, true));
+    }
+
+    @Test
+    public void namespacesTrueDoesNotActuallyEnableNamespaceProcessing() throws Exception {
+        // characterization: setting NAMESPACES=true does not change the qName/uri/localName
+        // reporting at all; uri is always empty because namespace processing is never performed.
+        final List<String> out = saxQNameUriLocal(WELL_FORMED_HTML);
+        assertFalse(out.isEmpty(), out.toString());
+        for (final String entry : out) {
+            assertTrue(entry.contains("|uri=|"), entry);
+        }
+    }
+
+    // =========================================================================
+    // AUGMENTATIONS: no-op
+    // =========================================================================
+
+    @Test
+    public void augmentationsTrueIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, AUGMENTATIONS, true));
+    }
+
+    @Test
+    public void augmentationsFalseIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, AUGMENTATIONS, false));
+    }
+
+    @Test
+    public void augmentationsTrueIsNoOpOnHeadlessHtml() throws Exception {
+        assertEquals(saxEvents(HEADLESS_HTML), saxEventsWithFeature(HEADLESS_HTML, AUGMENTATIONS, true));
+    }
+
+    @Test
+    public void augmentationsTrueIsNoOpOnHtmlWithAttributes() throws Exception {
+        assertEquals(saxEvents(ATTR_HTML), saxEventsWithFeature(ATTR_HTML, AUGMENTATIONS, true));
+    }
+
+    // =========================================================================
+    // REPORT_ERRORS: no-op (well-formed input has nothing to report anyway, but this locks
+    // that turning it on doesn't alter the observable SAX event stream via the content handler)
+    // =========================================================================
+
+    @Test
+    public void reportErrorsTrueIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, REPORT_ERRORS, true));
+    }
+
+    @Test
+    public void reportErrorsFalseIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, REPORT_ERRORS, false));
+    }
+
+    @Test
+    public void reportErrorsTrueIsNoOpOnHeadlessHtml() throws Exception {
+        assertEquals(saxEvents(HEADLESS_HTML), saxEventsWithFeature(HEADLESS_HTML, REPORT_ERRORS, true));
+    }
+
+    // =========================================================================
+    // SIMPLE_ERROR_FORMAT: no-op
+    // =========================================================================
+
+    @Test
+    public void simpleErrorFormatTrueIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, SIMPLE_ERROR_FORMAT, true));
+    }
+
+    @Test
+    public void simpleErrorFormatFalseIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, SIMPLE_ERROR_FORMAT, false));
+    }
+
+    @Test
+    public void simpleErrorFormatTrueIsNoOpOnHtmlWithAttributes() throws Exception {
+        assertEquals(saxEvents(ATTR_HTML), saxEventsWithFeature(ATTR_HTML, SIMPLE_ERROR_FORMAT, true));
+    }
+
+    // =========================================================================
+    // HTML5_MODE: no-op
+    // =========================================================================
+
+    @Test
+    public void html5ModeTrueIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, HTML5_MODE, true));
+    }
+
+    @Test
+    public void html5ModeFalseIsNoOpOnWellFormedHtml() throws Exception {
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, HTML5_MODE, false));
+    }
+
+    @Test
+    public void html5ModeTrueIsNoOpOnHeadlessHtml() throws Exception {
+        assertEquals(saxEvents(HEADLESS_HTML), saxEventsWithFeature(HEADLESS_HTML, HTML5_MODE, true));
+    }
+
+    @Test
+    public void html5ModeTrueIsNoOpOnHtmlWithAttributes() throws Exception {
+        assertEquals(saxEvents(ATTR_HTML), saxEventsWithFeature(ATTR_HTML, HTML5_MODE, true));
+    }
+
+    // =========================================================================
+    // BALANCE_TAGS: the one feature that DOES change output
+    // =========================================================================
+
+    @Test
+    public void balanceTagsTrueEqualsBaselineDefault() throws Exception {
+        // characterization: balance-tags defaults to true, so explicitly setting it true reproduces
+        // the same event stream as the baseline helper (which never touches this feature).
+        assertEquals(saxEvents(WELL_FORMED_HTML), saxEventsWithFeature(WELL_FORMED_HTML, BALANCE_TAGS, true));
+    }
+
+    @Test
+    public void balanceTagsFalseChangesUnclosedParagraphEventStream() throws Exception {
+        final List<String> balanced = saxEvents("<p>text");
+        final List<String> unbalanced = saxEventsWithFeature("<p>text", BALANCE_TAGS, false);
+
+        // characterization: turning balance-tags off produces an observably different event stream
+        assertNotEquals(balanced, unbalanced);
+        assertTrue(balanced.contains("end:P"), balanced.toString());
+        assertFalse(unbalanced.contains("end:P"), unbalanced.toString());
+    }
+
+    @Test
+    public void balanceTagsFalseSkipsImplicitHtmlRootInsertion() throws Exception {
+        final List<String> unbalanced = saxEventsWithFeature("<p>text", BALANCE_TAGS, false);
+        // characterization: with the tag balancer filter removed from the pipeline, the implicit
+        // HTML root insertion (which lives inside HTMLTagBalancerFilter) never happens either.
+        assertFalse(unbalanced.contains("start:HTML"), unbalanced.toString());
+        assertTrue(unbalanced.contains("start:P"), unbalanced.toString());
+    }
+
+    @Test
+    public void balanceTagsFalseStillAutoClosesVoidElements() throws Exception {
+        // characterization: void-element auto-closing happens in the scanner itself (not the
+        // balancer filter), so it still fires even with balance-tags off.
+        final List<String> events = saxEventsWithFeature("<br>", BALANCE_TAGS, false);
+        assertTrue(events.contains("start:BR"), events.toString());
+        assertTrue(events.contains("end:BR"), events.toString());
+    }
+
+    @Test
+    public void balanceTagsFalseOnAlreadyWellFormedHtmlLocksActualEventStream() throws Exception {
+        final List<String> baseline = saxEvents(WELL_FORMED_HTML);
+        final List<String> unbalanced = saxEventsWithFeature(WELL_FORMED_HTML, BALANCE_TAGS, false);
+        // characterization: with input that is already fully well-formed, disabling the tag
+        // balancer filter produces the identical event stream to the balanced baseline, since there
+        // was nothing left to balance/auto-insert.
+        assertEquals(baseline, unbalanced);
+    }
+
+    // =========================================================================
+    // Round-trip getFeature for BALANCE_TAGS on the public SAXParser
+    // =========================================================================
+
+    @Test
+    public void balanceTagsFeatureRoundTripsThroughSetAndGet() throws Exception {
+        final SAXParser parser = new SAXParser();
+        assertTrue(parser.getFeature(BALANCE_TAGS));
+        parser.setFeature(BALANCE_TAGS, false);
+        assertFalse(parser.getFeature(BALANCE_TAGS));
+        parser.setFeature(BALANCE_TAGS, true);
+        assertTrue(parser.getFeature(BALANCE_TAGS));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidDoctypeTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidDoctypeTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.lexicalEvents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for {@code DOCTYPE} handling on VALID/well-formed HTML, through both the
+ * {@code DOMParser} path (DOCTYPE never becomes part of the DOM) and the plain {@code SAXParser} path
+ * with a {@link org.xml.sax.ext.LexicalHandler} registered (DOCTYPE reaches the handler as a
+ * startDTD/endDTD pair, but always with a hardcoded name and null ids).
+ */
+public class ValidDoctypeTest {
+
+    @Test
+    public void doctypeIsDroppedFromDomButRestOfDocumentParses() throws Exception {
+        final Document doc = parse("<!DOCTYPE html><html><body><p>x</p></body></html>");
+        // characterization: DOCTYPE never becomes a DOM DocumentType node
+        assertNull(doc.getDoctype());
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void doctypeDoesNotLeakAsTextIntoDom() throws Exception {
+        final Document doc = parse("<!DOCTYPE html><html><body><p>x</p></body></html>");
+        assertEquals(0, count(doc, "//text()[contains(.,'DOCTYPE')]"));
+    }
+
+    @Test
+    public void saxEmitsStartDtdThenEndDtdForBasicDoctype() throws Exception {
+        final List<String> events = lexicalEvents("<!DOCTYPE html><p>x</p>");
+        // characterization: name is always the literal "html"; publicId/systemId are always null
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+        assertTrue(events.contains("endDTD"), events.toString());
+        assertTrue(events.indexOf("startDTD:html|null|null") < events.indexOf("endDTD"), events.toString());
+    }
+
+    @Test
+    public void legacyPublicDoctypeStillReportsNullPublicAndSystemIds() throws Exception {
+        final List<String> events =
+                lexicalEvents("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><p>x</p>");
+        // characterization: publicId/systemId are never captured, even for a legacy doctype that has them
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+        assertTrue(events.contains("endDTD"), events.toString());
+    }
+
+    @Test
+    public void lowercaseDoctypeKeywordEmitsSameStartDtd() throws Exception {
+        final List<String> events = lexicalEvents("<!doctype html><p>x</p>");
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+        assertTrue(events.contains("endDTD"), events.toString());
+    }
+
+    @Test
+    public void xhtmlDoctypeEmitsSameStartDtd() throws Exception {
+        final List<String> events =
+                lexicalEvents("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
+                        + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><p>x</p>");
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+        assertTrue(events.contains("endDTD"), events.toString());
+    }
+
+    @Test
+    public void doctypeNameIsAlwaysHardcodedHtmlRegardlessOfActualContent() throws Exception {
+        // characterization: the DTD name reported to the lexical handler is a hardcoded literal
+        // "html", not derived from the actual DOCTYPE content
+        final List<String> events = lexicalEvents("<!DOCTYPE foo><p>x</p>");
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+    }
+
+    @Test
+    public void startDocumentPrecedesStartDtd() throws Exception {
+        final List<String> events = lexicalEvents("<!DOCTYPE html><p>x</p>");
+        assertTrue(events.indexOf("startDocument") < events.indexOf("startDTD:html|null|null"), events.toString());
+    }
+
+    @Test
+    public void startDtdAndEndDtdPrecedeFirstStartElement() throws Exception {
+        final List<String> events = lexicalEvents("<!DOCTYPE html><p>x</p>");
+        final int startDtd = events.indexOf("startDTD:html|null|null");
+        final int endDtd = events.indexOf("endDTD");
+        final int startP = events.indexOf("start:P");
+        assertTrue(startDtd < endDtd, events.toString());
+        assertTrue(endDtd < startP, events.toString());
+    }
+
+    @Test
+    public void endDtdImmediatelyFollowsStartDtdWithNoInterveningEvents() throws Exception {
+        final List<String> events = lexicalEvents("<!DOCTYPE html><p>x</p>");
+        final int startDtd = events.indexOf("startDTD:html|null|null");
+        final int endDtd = events.indexOf("endDTD");
+        assertEquals(startDtd + 1, endDtd, events.toString());
+    }
+
+    @Test
+    public void noDoctypeMeansNoDtdEvents() throws Exception {
+        final List<String> events = lexicalEvents("<p>x</p>");
+        assertFalse(events.stream().anyMatch(e -> e.startsWith("startDTD")), events.toString());
+        assertFalse(events.contains("endDTD"), events.toString());
+    }
+
+    @Test
+    public void lowercaseDoctypeDroppedFromDomToo() throws Exception {
+        final Document doc = parse("<!doctype html><p>x</p>");
+        assertNull(doc.getDoctype());
+        assertEquals(1, count(doc, "//P"));
+    }
+
+    @Test
+    public void doctypeFollowedByBodylessContentOnlyAutoInsertsHtmlRoot() throws Exception {
+        // characterization: HEAD/BODY are never auto-created, even after a DOCTYPE
+        final Document doc = parse("<!DOCTYPE html><p>x</p>");
+        assertEquals(1, count(doc, "//HTML"));
+        assertEquals(0, count(doc, "//BODY"));
+        assertEquals(1, count(doc, "//HTML/P"));
+    }
+
+    @Test
+    public void doctypeWithExtraWhitespaceBeforeNameStillRecognized() throws Exception {
+        final List<String> events = lexicalEvents("<!DOCTYPE    html><p>x</p>");
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+    }
+
+    @Test
+    public void multilineLegacyDoctypeStillRecognized() throws Exception {
+        final List<String> events =
+                lexicalEvents("<!DOCTYPE html PUBLIC\n\"-//W3C//DTD HTML 4.01//EN\"\n"
+                        + "\"http://www.w3.org/TR/html4/strict.dtd\"><p>x</p>");
+        assertTrue(events.contains("startDTD:html|null|null"), events.toString());
+        assertTrue(events.contains("endDTD"), events.toString());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidDomNodeContractTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidDomNodeContractTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.nodes;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.childSignature;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Characterization tests for the DOM node contract ({@code Node}/{@code Element}/{@code Document}
+ * behavior) produced by {@code DOMParser} on VALID/well-formed HTML input.
+ */
+public class ValidDomNodeContractTest {
+
+    // -----------------------------------------------------------------
+    // Combined structure: comment + attribute + mixed content
+    // -----------------------------------------------------------------
+
+    @Test
+    public void documentElementIsUppercaseHtml() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        assertEquals("HTML", doc.getDocumentElement().getNodeName());
+    }
+
+    @Test
+    public void getElementsByTagNameFindsSingleP() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        assertEquals(1, doc.getElementsByTagName("P").getLength());
+    }
+
+    @Test
+    public void pElementHasIdAttributeViaNamedNodeMap() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        final Element p = (Element) doc.getElementsByTagName("P").item(0);
+        assertEquals("x", p.getAttributes().getNamedItem("id").getNodeValue());
+    }
+
+    @Test
+    public void pChildSignatureCapturesTextBrTextInOrder() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        final Element p = (Element) doc.getElementsByTagName("P").item(0);
+        assertEquals(List.of("text:t", "elem:BR", "text:u"), childSignature(p));
+    }
+
+    @Test
+    public void brElementHasNoChildNodes() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        final Element br = (Element) doc.getElementsByTagName("BR").item(0);
+        assertFalse(br.hasChildNodes());
+    }
+
+    @Test
+    public void commentNodeExistsWithExpectedValue() throws Exception {
+        final Document doc = parse("<html><body><!--c--><p id=\"x\">t<br>u</p></body></html>");
+        final NodeList comments = nodes(doc, "//comment()");
+        assertEquals(1, comments.getLength());
+        final Node c = comments.item(0);
+        assertEquals(Node.COMMENT_NODE, c.getNodeType());
+        assertEquals("c", c.getNodeValue());
+        assertTrue(c instanceof Comment);
+    }
+
+    // -----------------------------------------------------------------
+    // Owner document
+    // -----------------------------------------------------------------
+
+    @Test
+    public void ownerDocumentIsSameForRootElement() throws Exception {
+        final Document doc = parse("<html><body><p id=\"x\">t</p></body></html>");
+        assertSame(doc, doc.getDocumentElement().getOwnerDocument());
+    }
+
+    @Test
+    public void ownerDocumentIsSameForNestedElement() throws Exception {
+        final Document doc = parse("<html><body><p id=\"x\">t</p></body></html>");
+        final Element p = (Element) doc.getElementsByTagName("P").item(0);
+        assertSame(doc, p.getOwnerDocument());
+    }
+
+    @Test
+    public void ownerDocumentIsSameForTextNode() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        final Element p = first(doc, "//P");
+        final Node text = p.getFirstChild();
+        assertEquals(Node.TEXT_NODE, text.getNodeType());
+        assertSame(doc, text.getOwnerDocument());
+    }
+
+    @Test
+    public void ownerDocumentIsSameForCommentNode() throws Exception {
+        final Document doc = parse("<p>a<!--c-->b</p>");
+        final NodeList comments = nodes(doc, "//comment()");
+        assertSame(doc, comments.item(0).getOwnerDocument());
+    }
+
+    @Test
+    public void ownerDocumentNeverNullAcrossMultipleElements() throws Exception {
+        final Document doc = parse("<html><body><div><p>a</p><span>b</span></div></body></html>");
+        final NodeList all = doc.getElementsByTagName("*");
+        for (int i = 0; i < all.getLength(); i++) {
+            assertNotNull(all.item(i).getOwnerDocument());
+            assertSame(doc, all.item(i).getOwnerDocument());
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Node types
+    // -----------------------------------------------------------------
+
+    @Test
+    public void documentNodeTypeIsDocument() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        assertEquals(Node.DOCUMENT_NODE, doc.getNodeType());
+        assertEquals(9, doc.getNodeType());
+    }
+
+    @Test
+    public void documentElementNodeTypeIsElement() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        assertEquals(Node.ELEMENT_NODE, doc.getDocumentElement().getNodeType());
+        assertEquals(1, doc.getDocumentElement().getNodeType());
+    }
+
+    @Test
+    public void textNodeTypeIsText() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        final Node text = first(doc, "//P").getFirstChild();
+        assertEquals(Node.TEXT_NODE, text.getNodeType());
+        assertEquals(3, text.getNodeType());
+    }
+
+    @Test
+    public void commentNodeTypeIsComment() throws Exception {
+        final Document doc = parse("<p>a<!--c-->b</p>");
+        final Node comment = nodes(doc, "//comment()").item(0);
+        assertEquals(Node.COMMENT_NODE, comment.getNodeType());
+        assertEquals(8, comment.getNodeType());
+    }
+
+    // -----------------------------------------------------------------
+    // getElementsByTagName("*") document order
+    // -----------------------------------------------------------------
+
+    @Test
+    public void getElementsByTagNameWildcardReturnsDocumentOrder() throws Exception {
+        final Document doc = parse("<html><body><div><p>a</p><span>b</span></div></body></html>");
+        final NodeList all = doc.getElementsByTagName("*");
+        final StringBuilder names = new StringBuilder();
+        for (int i = 0; i < all.getLength(); i++) {
+            if (i > 0) {
+                names.append(",");
+            }
+            names.append(all.item(i).getNodeName());
+        }
+        // characterization: HTML and BODY are present as real elements in document order
+        assertEquals("HTML,BODY,DIV,P,SPAN", names.toString());
+    }
+
+    // -----------------------------------------------------------------
+    // Text content
+    // -----------------------------------------------------------------
+
+    @Test
+    public void firstTextReturnsSimpleParagraphText() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        assertEquals("a", firstText(doc, "//P"));
+    }
+
+    // -----------------------------------------------------------------
+    // Attributes NamedNodeMap
+    // -----------------------------------------------------------------
+
+    @Test
+    public void attributesNamedNodeMapHasThreeEntries() throws Exception {
+        final Document doc = parse("<div id=\"a\" class=\"b\" data-x=\"1\">t</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals(3, div.getAttributes().getLength());
+    }
+
+    @Test
+    public void attributesNamedNodeMapReadsClassAndDataAttribute() throws Exception {
+        final Document doc = parse("<div id=\"a\" class=\"b\" data-x=\"1\">t</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("b", div.getAttributes().getNamedItem("class").getNodeValue());
+        assertEquals("1", div.getAttributes().getNamedItem("data-x").getNodeValue());
+    }
+
+    @Test
+    public void attributesNamedNodeMapReturnsNullForMissingAttribute() throws Exception {
+        final Document doc = parse("<div id=\"a\" class=\"b\" data-x=\"1\">t</div>");
+        final Element div = first(doc, "//DIV");
+        assertNull(div.getAttributes().getNamedItem("nope"));
+    }
+
+    // -----------------------------------------------------------------
+    // Multiple same-name elements
+    // -----------------------------------------------------------------
+
+    @Test
+    public void getElementsByTagNameLiFindsTwoItems() throws Exception {
+        final Document doc = parse("<ul><li>1</li><li>2</li></ul>");
+        assertEquals(2, doc.getElementsByTagName("LI").getLength());
+    }
+
+    @Test
+    public void liItemsHaveExpectedTextInOrder() throws Exception {
+        final Document doc = parse("<ul><li>1</li><li>2</li></ul>");
+        final NodeList lis = doc.getElementsByTagName("LI");
+        assertEquals("1", lis.item(0).getTextContent());
+        assertEquals("2", lis.item(1).getTextContent());
+    }
+
+    // -----------------------------------------------------------------
+    // Empty element
+    // -----------------------------------------------------------------
+
+    @Test
+    public void brElementParsedAloneHasNoChildNodes() throws Exception {
+        final Document doc = parse("<br>");
+        final Element br = first(doc, "//BR");
+        assertFalse(br.hasChildNodes());
+    }
+
+    @Test
+    public void brElementParsedAloneIsUnderAutoInsertedHtmlOnly() throws Exception {
+        final Document doc = parse("<br>");
+        // characterization: only HTML is auto-inserted; HEAD/BODY are never auto-created
+        assertEquals("HTML", doc.getDocumentElement().getNodeName());
+        assertEquals(0, count(doc, "//BODY"));
+    }
+
+    // -----------------------------------------------------------------
+    // NamedNodeMap absence on elements without attributes
+    // -----------------------------------------------------------------
+
+    @Test
+    public void elementWithoutAttributesHasEmptyNamedNodeMap() throws Exception {
+        final Document doc = parse("<p>a</p>");
+        final Element p = first(doc, "//P");
+        final NamedNodeMap attrs = p.getAttributes();
+        assertNotNull(attrs);
+        assertEquals(0, attrs.getLength());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidEncodingBomTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidEncodingBomTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.parseBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+/**
+ * Characterization tests locking in {@code SimpleHTMLScanner}'s byte-stream decoding behavior:
+ * which {@link org.xml.sax.InputSource} encoding label is honored, what happens on a {@code null}
+ * encoding, whether {@code <meta charset>} / {@code http-equiv} declarations are auto-detected, and
+ * how (or whether) a leading byte-order-mark is handled. All input HTML here is otherwise
+ * well-formed; only the byte-level decoding path is under test.
+ */
+public class ValidEncodingBomTest {
+
+    // -----------------------------------------------------------------
+    // Explicit encoding labels
+    // -----------------------------------------------------------------
+
+    @Test
+    public void isoLatin1DecodesByteStreamWithExplicitEncoding() throws Exception {
+        final byte[] bytes = "<p>café</p>".getBytes("ISO-8859-1");
+        final Document doc = parseBytes(bytes, "ISO-8859-1");
+        assertEquals("café", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void utf8DecodesByteStreamWithNullEncodingDefaultingToUtf8() throws Exception {
+        // characterization: a null InputSource encoding defaults to "UTF-8" (per SimpleHTMLScanner).
+        final byte[] bytes = "<p>café</p>".getBytes("UTF-8");
+        final Document doc = parseBytes(bytes, null);
+        assertEquals("café", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void utf8DecodesByteStreamWithExplicitEncoding() throws Exception {
+        final byte[] bytes = "<p>café</p>".getBytes("UTF-8");
+        final Document doc = parseBytes(bytes, "UTF-8");
+        assertEquals("café", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void shiftJisDecodesMultibyteJapaneseText() throws Exception {
+        final byte[] bytes = "<p>日本語</p>".getBytes("Shift_JIS");
+        final Document doc = parseBytes(bytes, "Shift_JIS");
+        assertEquals("日本語", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void windows1252DecodesExtendedLatinAndEuroSign() throws Exception {
+        final byte[] bytes = "<p>café €</p>".getBytes("windows-1252");
+        final Document doc = parseBytes(bytes, "windows-1252");
+        assertEquals("café €", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void isoLatin1DecodesAttributeValueWithExplicitEncoding() throws Exception {
+        final byte[] bytes = "<p title=\"café\">x</p>".getBytes("ISO-8859-1");
+        final Document doc = parseBytes(bytes, "ISO-8859-1");
+        assertEquals("café", first(doc, "//P").getAttribute("title"));
+    }
+
+    @Test
+    public void shiftJisDecodesAttributeValueWithExplicitEncoding() throws Exception {
+        final byte[] bytes = "<p title=\"日本語\">x</p>".getBytes("Shift_JIS");
+        final Document doc = parseBytes(bytes, "Shift_JIS");
+        assertEquals("日本語", first(doc, "//P").getAttribute("title"));
+    }
+
+    // -----------------------------------------------------------------
+    // Encoding mismatch (mojibake)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void utf8BytesDecodedAsIsoLatin1ProduceMojibake() throws Exception {
+        // characterization: the UTF-8 two-byte sequence for 'é' (0xC3 0xA9) is mis-decoded, one byte
+        // at a time, as ISO-8859-1, expanding a single character into two mojibake characters.
+        final byte[] bytes = "<p>café</p>".getBytes("UTF-8");
+        final Document doc = parseBytes(bytes, "ISO-8859-1");
+        final String text = firstText(doc, "//P");
+        assertEquals("cafÃ©", text);
+        assertEquals(5, text.length());
+        assertEquals('Ã', text.charAt(3));
+        assertEquals('©', text.charAt(4));
+    }
+
+    // -----------------------------------------------------------------
+    // <meta charset> / http-equiv are NOT auto-detected
+    // -----------------------------------------------------------------
+
+    @Test
+    public void metaCharsetTagIsNotAutoDetectedForDecoding() throws Exception {
+        final String html = "<html><head><meta charset=\"Shift_JIS\"></head><body><p>x</p></body></html>";
+        // characterization: the document bytes are actually UTF-8, but the byte stream is parsed
+        // with the default (UTF-8) decoding regardless of the <meta charset> declaration.
+        final Document doc = parseBytes(html.getBytes("UTF-8"), null);
+        assertEquals(1, count(doc, "//META"));
+        assertEquals("x", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void metaCharsetAttributeValueIsPreservedVerbatim() throws Exception {
+        final String html = "<html><head><meta charset=\"Shift_JIS\"></head><body><p>x</p></body></html>";
+        final Document doc = parseBytes(html.getBytes("UTF-8"), null);
+        // characterization: the meta tag itself still parses normally; only its charset value has no
+        // effect on decoding.
+        assertEquals("Shift_JIS", first(doc, "//META").getAttribute("charset"));
+    }
+
+    @Test
+    public void httpEquivContentTypeMetaIsNotAutoDetectedForDecoding() throws Exception {
+        final String html =
+                "<html><head>" + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"></head>"
+                        + "<body><p>y</p></body></html>";
+        final Document doc = parseBytes(html.getBytes("UTF-8"), null);
+        assertEquals(1, count(doc, "//META"));
+        assertEquals("y", firstText(doc, "//P"));
+    }
+
+    // -----------------------------------------------------------------
+    // Byte-order-mark handling
+    // -----------------------------------------------------------------
+
+    @Test
+    public void utf8BomIsNotStrippedAndSurvivesAsLeadingTextCharacter() throws Exception {
+        // characterization: SimpleHTMLScanner does not detect or strip a leading UTF-8 BOM; decoded as
+        // UTF-8, the three BOM bytes (EF BB BF) become a single U+FEFF character that shows up as a
+        // leading text node sibling of <P>, not merged into <P>'s own text.
+        final byte[] bom = concat(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF }, "<p>x</p>".getBytes("UTF-8"));
+        final Document doc = parseBytes(bom, "UTF-8");
+
+        assertEquals("x", firstText(doc, "//P"));
+        final Node htmlFirstChild = first(doc, "//HTML").getFirstChild();
+        assertEquals(Node.TEXT_NODE, htmlFirstChild.getNodeType());
+        assertEquals(1, htmlFirstChild.getNodeValue().length());
+        assertEquals(0xFEFF, (int) htmlFirstChild.getNodeValue().charAt(0));
+    }
+
+    @Test
+    public void utf8BomIsNotStrippedWithNullEncodingEither() throws Exception {
+        final byte[] bom = concat(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF }, "<p>x</p>".getBytes("UTF-8"));
+        final Document doc = parseBytes(bom, null);
+
+        assertEquals("x", firstText(doc, "//P"));
+        final Node htmlFirstChild = first(doc, "//HTML").getFirstChild();
+        assertEquals(Node.TEXT_NODE, htmlFirstChild.getNodeType());
+        assertEquals(0xFEFF, (int) htmlFirstChild.getNodeValue().charAt(0));
+    }
+
+    @Test
+    public void documentElementIsStillTheSoleRootChildDespiteLeadingBom() throws Exception {
+        final byte[] bom = concat(new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF }, "<p>x</p>".getBytes("UTF-8"));
+        final Document doc = parseBytes(bom, "UTF-8");
+        // characterization: the BOM character is folded into <HTML>'s text content, not left as a
+        // sibling of <HTML> at the Document level.
+        assertEquals(1, doc.getChildNodes().getLength());
+        assertEquals("HTML", doc.getDocumentElement().getNodeName());
+    }
+
+    // -----------------------------------------------------------------
+    // Character stream bypasses byte decoding entirely
+    // -----------------------------------------------------------------
+
+    @Test
+    public void characterStreamParsingIgnoresEncodingEntirely() throws Exception {
+        // characterization: parsing a java.io.StringReader-backed InputSource never touches
+        // InputSource#getEncoding(); the already-decoded Java String is used verbatim.
+        final Document doc = parse("<p>café</p>");
+        assertEquals("café", firstText(doc, "//P"));
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private static byte[] concat(final byte[] a, final byte[] b) throws Exception {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bos.write(a);
+        bos.write(b);
+        final byte[] result = bos.toByteArray();
+        assertNotNull(result);
+        return result;
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidEntityDecodingTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidEntityDecodingTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests locking in end-to-end HTML entity decoding (named and numeric) through the
+ * full {@code DOMParser} parse path, for both text content and attribute values, on VALID/well-formed
+ * HTML input.
+ */
+public class ValidEntityDecodingTest {
+
+    // -----------------------------------------------------------------
+    // Named entities in text
+    // -----------------------------------------------------------------
+
+    @Test
+    public void ampEntityDecodesInText() throws Exception {
+        final Document doc = parse("<p>Tom &amp; Jerry</p>");
+        assertEquals("Tom & Jerry", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void ltGtEntitiesDecodeToAngleBrackets() throws Exception {
+        final Document doc = parse("<p>&lt;tag&gt;</p>");
+        assertEquals("<tag>", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void copyEntityDecodesToCopyrightSign() throws Exception {
+        final Document doc = parse("<p>&copy; 2024</p>");
+        assertEquals("© 2024", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void eacuteEntityDecodesInsideWord() throws Exception {
+        final Document doc = parse("<p>caf&eacute;</p>");
+        assertEquals("café", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void mdashEntityDecodesToEmDash() throws Exception {
+        final Document doc = parse("<p>a &mdash; b</p>");
+        assertEquals("a — b", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void nbspEntityDecodesToNonBreakingSpaceNotRegularSpace() throws Exception {
+        final Document doc = parse("<p>&nbsp;end</p>");
+        final String text = firstText(doc, "//P");
+        // characterization: &nbsp; decodes to U+00A0 NO-BREAK SPACE, not a regular U+0020 space.
+        assertEquals(' ', text.charAt(0));
+        assertEquals(" end", text);
+    }
+
+    @Test
+    public void quotEntityDecodesToDoubleQuote() throws Exception {
+        final Document doc = parse("<p>&quot;q&quot;</p>");
+        assertEquals("\"q\"", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void aposEntityDecodesToApostrophe() throws Exception {
+        final Document doc = parse("<p>&apos;a&apos;</p>");
+        assertEquals("'a'", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void upperCaseAmpEntityIsCaseSensitiveAndNotDecoded() throws Exception {
+        // characterization: entity name lookup is case-sensitive; "AMP" is not a known entity name
+        // (only lower-case "amp" is), so "&AMP;" is left completely literal.
+        final Document doc = parse("<p>&AMP;</p>");
+        assertEquals("&AMP;", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void unknownNamedEntityIsLeftLiteralInText() throws Exception {
+        final Document doc = parse("<p>&foobar;</p>");
+        assertEquals("&foobar;", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void semicolonOptionalForNamedEntityInText() throws Exception {
+        // characterization: the trailing ';' is optional for named entities in text context.
+        final Document doc = parse("<p>&copy 2024</p>");
+        assertEquals("© 2024", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void regEntityDecodesToRegisteredSign() throws Exception {
+        final Document doc = parse("<p>&reg;</p>");
+        assertEquals("®", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void tradeEntityDecodesToTradeMarkSign() throws Exception {
+        final Document doc = parse("<p>&trade;</p>");
+        assertEquals("™", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hellipEntityDecodesToHorizontalEllipsis() throws Exception {
+        final Document doc = parse("<p>&hellip;</p>");
+        assertEquals("…", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void ndashEntityDecodesToEnDash() throws Exception {
+        final Document doc = parse("<p>&ndash;</p>");
+        assertEquals("–", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void lsquoEntityDecodesToLeftSingleQuote() throws Exception {
+        final Document doc = parse("<p>&lsquo;</p>");
+        assertEquals("‘", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void rsquoEntityDecodesToRightSingleQuote() throws Exception {
+        final Document doc = parse("<p>&rsquo;</p>");
+        assertEquals("’", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void ldquoEntityDecodesToLeftDoubleQuote() throws Exception {
+        final Document doc = parse("<p>&ldquo;</p>");
+        assertEquals("“", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void rdquoEntityDecodesToRightDoubleQuote() throws Exception {
+        final Document doc = parse("<p>&rdquo;</p>");
+        assertEquals("”", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void degEntityDecodesToDegreeSign() throws Exception {
+        final Document doc = parse("<p>&deg;</p>");
+        assertEquals("°", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void timesEntityDecodesToMultiplicationSign() throws Exception {
+        final Document doc = parse("<p>&times;</p>");
+        assertEquals("×", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void divideEntityDecodesToDivisionSign() throws Exception {
+        final Document doc = parse("<p>&divide;</p>");
+        assertEquals("÷", firstText(doc, "//P"));
+    }
+
+    // -----------------------------------------------------------------
+    // Named entities in attribute values
+    // -----------------------------------------------------------------
+
+    @Test
+    public void ampEntityDecodesInHrefAttribute() throws Exception {
+        final Document doc = parse("<a href=\"?a=1&amp;b=2\">x</a>");
+        assertEquals("?a=1&b=2", first(doc, "//A").getAttribute("href"));
+    }
+
+    @Test
+    public void copyEntityDecodesInsideAttributeValue() throws Exception {
+        final Document doc = parse("<a href=\"x&copy;z\">x</a>");
+        assertEquals("x©z", first(doc, "//A").getAttribute("href"));
+    }
+
+    @Test
+    public void numericHexEntityDecodesInAltAttribute() throws Exception {
+        final Document doc = parse("<img alt=\"&#169; me\">");
+        assertEquals("© me", first(doc, "//IMG").getAttribute("alt"));
+    }
+
+    @Test
+    public void semicolonlessNamedEntityFollowedByEqualsStaysLiteralInAttribute() throws Exception {
+        // characterization: HTML5 attribute-value-state guard - a semicolon-less named entity
+        // immediately followed by '=' or an alphanumeric is NOT decoded in an attribute value, so
+        // query strings like "?not=1&copy=2" survive untouched.
+        final Document doc = parse("<a href=\"q?not=1&copy=2\">x</a>");
+        assertEquals("q?not=1&copy=2", first(doc, "//A").getAttribute("href"));
+    }
+
+    @Test
+    public void ltGtEntitiesDecodeInTitleAttribute() throws Exception {
+        final Document doc = parse("<a title=\"&lt;x&gt;\">x</a>");
+        assertEquals("<x>", first(doc, "//A").getAttribute("title"));
+    }
+
+    @Test
+    public void aposEntityDecodesInAttributeValue() throws Exception {
+        final Document doc = parse("<a title=\"&apos;quoted&apos;\">x</a>");
+        assertEquals("'quoted'", first(doc, "//A").getAttribute("title"));
+    }
+
+    @Test
+    public void semicolonlessNamedEntityFollowedByNonAlnumDecodesInAttribute() throws Exception {
+        // characterization: the attribute-value-state guard only blocks decoding when the next
+        // character is alphanumeric or '='; a following space still allows decoding.
+        final Document doc = parse("<a title=\"&copy 2024\">x</a>");
+        assertEquals("© 2024", first(doc, "//A").getAttribute("title"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidHtmlTestSupport.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidHtmlTestSupport.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Shared helper for VALID / happy-path HTML characterization tests.
+ *
+ * <p>
+ * Adds lexical-event capture, byte-stream parsing, feature toggling and DOM
+ * child-signature helpers on top of {@link BrokenHtmlTestSupport}. Uses only
+ * the public {@code DOMParser}/{@code SAXParser} APIs.
+ * </p>
+ */
+public final class ValidHtmlTestSupport {
+
+    private ValidHtmlTestSupport() {
+    }
+
+    /** Parses HTML bytes with the given encoding label on the InputSource ({@code null} = default). */
+    public static Document parseBytes(final byte[] bytes, final String encoding) throws Exception {
+        final DOMParser parser = new DOMParser();
+        final InputSource source = new InputSource(new ByteArrayInputStream(bytes));
+        if (encoding != null) {
+            source.setEncoding(encoding);
+        }
+        parser.parse(source);
+        return parser.getDocument();
+    }
+
+    /** Captures the combined content + lexical event stream as strings. */
+    public static List<String> lexicalEvents(final String html) throws Exception {
+        final List<String> events = new ArrayList<>();
+        final SAXParser parser = new SAXParser();
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startDocument() {
+                events.add("startDocument");
+            }
+
+            @Override
+            public void endDocument() {
+                events.add("endDocument");
+            }
+
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) {
+                events.add("start:" + qName);
+            }
+
+            @Override
+            public void endElement(final String uri, final String localName, final String qName) {
+                events.add("end:" + qName);
+            }
+
+            @Override
+            public void characters(final char[] ch, final int start, final int length) {
+                events.add("chars:" + new String(ch, start, length));
+            }
+
+            @Override
+            public void processingInstruction(final String target, final String data) {
+                events.add("pi:" + target + "|" + data);
+            }
+        });
+        parser.setLexicalHandler(new LexicalHandler() {
+            @Override
+            public void comment(final char[] ch, final int start, final int length) {
+                events.add("comment:" + new String(ch, start, length));
+            }
+
+            @Override
+            public void startDTD(final String name, final String publicId, final String systemId) {
+                events.add("startDTD:" + name + "|" + publicId + "|" + systemId);
+            }
+
+            @Override
+            public void endDTD() {
+                events.add("endDTD");
+            }
+
+            @Override
+            public void startCDATA() {
+                events.add("startCDATA");
+            }
+
+            @Override
+            public void endCDATA() {
+                events.add("endCDATA");
+            }
+
+            @Override
+            public void startEntity(final String name) {
+            }
+
+            @Override
+            public void endEntity(final String name) {
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return events;
+    }
+
+    /** Collects one {@code "QN|uri=U|local=L"} descriptor per startElement. */
+    public static List<String> saxQNameUriLocal(final String html) throws Exception {
+        final List<String> out = new ArrayList<>();
+        final SAXParser parser = new SAXParser();
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) {
+                out.add(qName + "|uri=" + uri + "|local=" + localName);
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return out;
+    }
+
+    /** Collects start/end/chars events after setting one feature to a value. */
+    public static List<String> saxEventsWithFeature(final String html, final String feature, final boolean value) throws Exception {
+        final List<String> events = new ArrayList<>();
+        final SAXParser parser = new SAXParser();
+        parser.setFeature(feature, value);
+        parser.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) {
+                events.add("start:" + qName);
+            }
+
+            @Override
+            public void endElement(final String uri, final String localName, final String qName) {
+                events.add("end:" + qName);
+            }
+
+            @Override
+            public void characters(final char[] ch, final int start, final int length) {
+                events.add("chars:" + new String(ch, start, length));
+            }
+        });
+        parser.parse(new InputSource(new StringReader(html)));
+        return events;
+    }
+
+    /** Returns an ordered signature of a node's children. */
+    public static List<String> childSignature(final Node parent) {
+        final List<String> sig = new ArrayList<>();
+        final NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node n = children.item(i);
+            switch (n.getNodeType()) {
+            case Node.ELEMENT_NODE -> sig.add("elem:" + n.getNodeName());
+            case Node.TEXT_NODE -> sig.add("text:" + n.getNodeValue());
+            case Node.COMMENT_NODE -> sig.add("comment:" + n.getNodeValue());
+            case Node.CDATA_SECTION_NODE -> sig.add("cdata:" + n.getNodeValue());
+            case Node.PROCESSING_INSTRUCTION_NODE -> sig.add("pi:" + n.getNodeName() + "|" + n.getNodeValue());
+            default -> sig.add("other:" + n.getNodeType());
+            }
+        }
+        return sig;
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidHtmlTestSupportTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidHtmlTestSupportTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.childSignature;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.lexicalEvents;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.parseBytes;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.saxQNameUriLocal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Sanity tests for {@link ValidHtmlTestSupport}.
+ */
+public class ValidHtmlTestSupportTest {
+
+    @Test
+    public void lexicalEventsCapturesContentStream() throws Exception {
+        final List<String> ev = lexicalEvents("<p>x</p>");
+        assertTrue(ev.contains("startDocument"), ev.toString());
+        assertTrue(ev.contains("start:P"), ev.toString());
+        assertTrue(ev.contains("chars:x"), ev.toString());
+        assertTrue(ev.contains("end:P"), ev.toString());
+        assertTrue(ev.contains("endDocument"), ev.toString());
+    }
+
+    @Test
+    public void parseBytesDecodesUtf8() throws Exception {
+        final Document doc = parseBytes("<p>x</p>".getBytes(StandardCharsets.UTF_8), "UTF-8");
+        assertNotNull(doc);
+        assertEquals(1, count(doc, "//P"));
+        assertEquals("x", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void saxQNameUriLocalReportsUri() throws Exception {
+        final List<String> out = saxQNameUriLocal("<p>x</p>");
+        assertTrue(out.stream().anyMatch(s -> s.startsWith("P|uri=")), out.toString());
+    }
+
+    @Test
+    public void childSignatureListsChildrenInOrder() throws Exception {
+        final Document doc = parseBytes("<div>a<b>c</b></div>".getBytes(StandardCharsets.UTF_8), "UTF-8");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        assertTrue(sig.contains("text:a"), sig.toString());
+        assertTrue(sig.contains("elem:B"), sig.toString());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidNamespacePrefixTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidNamespacePrefixTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.saxQNameUriLocal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Characterization tests locking in NekoHTML's handling of colon-prefixed tag/attribute names (e.g.
+ * {@code <o:p>}, {@code xlink:href}) and of element/attribute name casing. NekoHTML does not perform
+ * XML namespace processing: prefixes are kept verbatim (uppercased for elements) in the SAX qName /
+ * DOM node name, {@code uri} is always empty, and {@code localName == qName}.
+ */
+public class ValidNamespacePrefixTest {
+
+    // -----------------------------------------------------------------
+    // Prefixed elements: SAX qName / uri / localName
+    // -----------------------------------------------------------------
+
+    @Test
+    public void prefixedElementSaxQNameIsUppercasedWithColonKept() throws Exception {
+        final List<String> out = saxQNameUriLocal("<o:p>x</o:p>");
+        assertTrue(out.contains("O:P|uri=|local=O:P"), out.toString());
+    }
+
+    @Test
+    public void prefixedElementSaxReportsEmptyUriAndLocalNameEqualsQName() throws Exception {
+        final List<String> out = saxQNameUriLocal("<o:p>x</o:p>");
+        final String entry = out.stream().filter(s -> s.startsWith("O:P|")).findFirst().orElseThrow();
+        assertEquals("O:P|uri=|local=O:P", entry);
+    }
+
+    @Test
+    public void multiplePrefixedElementsAreEachUppercasedIndependently() throws Exception {
+        final List<String> out = saxQNameUriLocal("<fb:like></fb:like><og:image></og:image>");
+        assertTrue(out.contains("FB:LIKE|uri=|local=FB:LIKE"), out.toString());
+        assertTrue(out.contains("OG:IMAGE|uri=|local=OG:IMAGE"), out.toString());
+    }
+
+    @Test
+    public void rootHtmlIsStillAutoInsertedAroundPrefixedContent() throws Exception {
+        final List<String> out = saxQNameUriLocal("<o:p>x</o:p>");
+        assertTrue(out.contains("HTML|uri=|local=HTML"), out.toString());
+    }
+
+    // -----------------------------------------------------------------
+    // Prefixed elements: DOM node identity (namespaces not processed)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void prefixedElementDomNodeNameIsUppercasedWithColonKept() throws Exception {
+        final Document doc = parse("<o:p>x</o:p>");
+        final Element el = (Element) doc.getElementsByTagName("O:P").item(0);
+        assertEquals("O:P", el.getNodeName());
+        assertEquals("O:P", el.getTagName());
+    }
+
+    @Test
+    public void prefixedElementHasNoNamespaceUri() throws Exception {
+        final Document doc = parse("<o:p>x</o:p>");
+        final Element el = (Element) doc.getElementsByTagName("O:P").item(0);
+        // characterization: NekoHTML never runs namespace processing, so a colon-containing tag name
+        // is just an (uppercased) local name, never split into prefix + namespace URI.
+        assertNull(el.getNamespaceURI());
+    }
+
+    @Test
+    public void prefixedElementHasNoPrefix() throws Exception {
+        final Document doc = parse("<o:p>x</o:p>");
+        final Element el = (Element) doc.getElementsByTagName("O:P").item(0);
+        assertNull(el.getPrefix());
+    }
+
+    @Test
+    public void prefixedElementHasNoLocalName() throws Exception {
+        final Document doc = parse("<o:p>x</o:p>");
+        final Element el = (Element) doc.getElementsByTagName("O:P").item(0);
+        // characterization: getLocalName() is null (not namespace-aware), unlike the SAX localName
+        // attribute value, which mirrors the qName instead.
+        assertNull(el.getLocalName());
+    }
+
+    // -----------------------------------------------------------------
+    // Namespaced/prefixed attribute names
+    // -----------------------------------------------------------------
+
+    @Test
+    public void namespacedAttributeValueIsPreservedVerbatim() throws Exception {
+        final Document doc = parse("<svg xmlns:xlink=\"http://x\"><use xlink:href=\"#a\"></use></svg>");
+        final Element use = first(doc, "//*[name()='USE']");
+        assertEquals("#a", use.getAttribute("xlink:href"));
+    }
+
+    @Test
+    public void namespacedElementCountIsOne() throws Exception {
+        final Document doc = parse("<svg xmlns:xlink=\"http://x\"><use xlink:href=\"#a\"></use></svg>");
+        assertEquals(1, count(doc, "//*[name()='USE']"));
+    }
+
+    @Test
+    public void namespacedAttributeNameIsLowercasedWithColonKept() throws Exception {
+        final Document doc = parse("<svg xmlns:xlink=\"http://x\"><use XLink:HREF=\"#b\"></use></svg>");
+        final Element use = first(doc, "//*[name()='USE']");
+        // characterization: the attribute name is stored lowercased ("xlink:href"), so a
+        // case-sensitive lookup using the original mixed-case source spelling misses entirely.
+        assertEquals("#b", use.getAttribute("xlink:href"));
+        assertEquals("", use.getAttribute("XLink:HREF"));
+    }
+
+    // -----------------------------------------------------------------
+    // Element/attribute casing (independent of any prefix)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void elementCasingIsNormalizedToUppercaseRegardlessOfSourceCase() throws Exception {
+        final Document doc = parse("<Div><SPAN>x</SPAN></div>");
+        assertEquals(1, doc.getElementsByTagName("DIV").getLength());
+        assertEquals(1, doc.getElementsByTagName("SPAN").getLength());
+    }
+
+    @Test
+    public void lowercaseClosingTagStillClosesAMixedCaseOpeningTag() throws Exception {
+        final Document doc = parse("<Div><SPAN>x</SPAN></div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("x", first(doc, "//SPAN").getTextContent());
+        assertEquals(1, div.getElementsByTagName("SPAN").getLength());
+    }
+
+    @Test
+    public void attributeNamesAreLowercasedRegardlessOfSourceCase() throws Exception {
+        final Document doc = parse("<div ID=\"a\" Class=\"c\" DATA-X=\"1\">t</div>");
+        final Element div = first(doc, "//DIV");
+        assertEquals("a", div.getAttribute("id"));
+        assertEquals("c", div.getAttribute("class"));
+        assertEquals("1", div.getAttribute("data-x"));
+    }
+
+    @Test
+    public void getAttributeIsCaseSensitiveOnTheStoredLowercaseName() throws Exception {
+        final Document doc = parse("<div ID=\"a\" Class=\"c\" DATA-X=\"1\">t</div>");
+        final Element div = first(doc, "//DIV");
+        // characterization: DOM's getAttribute() does a case-sensitive lookup against the stored
+        // (lowercased) attribute name, so querying with the original mixed-case spelling returns "".
+        assertEquals("", div.getAttribute("ID"));
+    }
+
+    // -----------------------------------------------------------------
+    // Custom/unknown elements
+    // -----------------------------------------------------------------
+
+    @Test
+    public void customElementIsAcceptedAsAnOrdinaryContainer() throws Exception {
+        final Document doc = parse("<my-widget><p>x</p></my-widget>");
+        assertEquals(1, doc.getElementsByTagName("MY-WIDGET").getLength());
+        final Element widget = first(doc, "//*[name()='MY-WIDGET']");
+        assertEquals(1, widget.getElementsByTagName("P").getLength());
+        assertEquals("x", widget.getElementsByTagName("P").item(0).getTextContent());
+    }
+
+    // -----------------------------------------------------------------
+    // SAX uri is always empty (no namespace processing at all)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void saxUriIsEmptyForEveryOrdinaryElement() throws Exception {
+        final List<String> out = saxQNameUriLocal("<div><p>x</p></div>");
+        assertEquals(3, out.size(), out.toString());
+        for (final String entry : out) {
+            assertTrue(entry.contains("|uri=|"), entry);
+        }
+    }
+
+    @Test
+    public void saxLocalNameEqualsQNameForEveryOrdinaryElement() throws Exception {
+        final List<String> out = saxQNameUriLocal("<div><p>x</p></div>");
+        assertTrue(out.contains("HTML|uri=|local=HTML"), out.toString());
+        assertTrue(out.contains("DIV|uri=|local=DIV"), out.toString());
+        assertTrue(out.contains("P|uri=|local=P"), out.toString());
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidNodeOrderingTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidNodeOrderingTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.first;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.childSignature;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Characterization tests for exact DOM child ordering, whitespace preservation, and the
+ * scanner's trailing-newline behavior on VALID/well-formed HTML input.
+ */
+public class ValidNodeOrderingTest {
+
+    @Test
+    public void mixedContentChildSignatureExact() throws Exception {
+        final Document doc = parse("<p>a <b>b</b> c</p>");
+        assertEquals(List.of("text:a ", "elem:B", "text: c"), childSignature(first(doc, "//P")));
+    }
+
+    @Test
+    public void whitespaceInsideDivIsNotCollapsed() throws Exception {
+        final Document doc = parse("<div>  spaced  </div>");
+        final String text = first(doc, "//DIV").getFirstChild().getNodeValue();
+        assertTrue(text.contains("  spaced  "), text);
+    }
+
+    @Test
+    public void multiLineTextKeepsEmbeddedNewline() throws Exception {
+        final Document doc = parse("<p>l1\nl2</p>");
+        final String text = first(doc, "//P").getFirstChild().getNodeValue();
+        assertTrue(text.contains("l1\nl2"), text);
+    }
+
+    @Test
+    public void trailingNewlineIsLastChildOfRoot() throws Exception {
+        final Document doc = parse("<p>x</p>");
+        final List<String> sig = childSignature(doc.getDocumentElement());
+        // characterization: the scanner appends '\n' after every line including EOF, surfacing as a
+        // trailing text node at the root element
+        assertEquals("text:\n", sig.get(sig.size() - 1));
+    }
+
+    @Test
+    public void nestedFormattingOrderPreservedForP() throws Exception {
+        final Document doc = parse("<p><b><i>x</i></b></p>");
+        final Node p = first(doc, "//P");
+        assertEquals(List.of("elem:B"), childSignature(p));
+    }
+
+    @Test
+    public void nestedFormattingOrderPreservedForB() throws Exception {
+        final Document doc = parse("<p><b><i>x</i></b></p>");
+        final Node b = first(doc, "//B");
+        assertEquals(List.of("elem:I"), childSignature(b));
+    }
+
+    @Test
+    public void nestedFormattingOrderPreservedForI() throws Exception {
+        final Document doc = parse("<p><b><i>x</i></b></p>");
+        final Node i = first(doc, "//I");
+        assertEquals(List.of("text:x"), childSignature(i));
+    }
+
+    @Test
+    public void adjacentTextRunsMergeIntoSingleTextChild() throws Exception {
+        final Document doc = parse("<p>ab</p>");
+        final Node p = first(doc, "//P");
+        assertEquals(1, p.getChildNodes().getLength());
+        assertEquals("ab", p.getFirstChild().getNodeValue());
+    }
+
+    @Test
+    public void entityAcrossRunMergesIntoSingleDecodedTextChild() throws Exception {
+        final Document doc = parse("<p>a&amp;b</p>");
+        final Node p = first(doc, "//P");
+        assertEquals(1, p.getChildNodes().getLength());
+        assertEquals("a&b", p.getFirstChild().getNodeValue());
+    }
+
+    @Test
+    public void betweenListItemsNewlinesAppearAsTextNodes() throws Exception {
+        final Document doc = parse("<ul>\n<li>a</li>\n<li>b</li>\n</ul>");
+        final List<String> sig = childSignature(first(doc, "//UL"));
+        assertEquals(List.of("text:\n", "elem:LI", "text:\n", "elem:LI", "text:\n"), sig);
+    }
+
+    @Test
+    public void commentInterleavingWithSurroundingText() throws Exception {
+        final Document doc = parse("<div>a<!--c-->b</div>");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        assertEquals(List.of("text:a", "comment:c", "text:b"), sig);
+    }
+
+    @Test
+    public void crNormalizationRemovesCarriageReturnFromTextNodes() throws Exception {
+        final Document doc = parse("<div>a\r\n<p>b</p>\r\nc</div>");
+        final NodeList texts = doc.getElementsByTagName("*");
+        for (int i = 0; i < texts.getLength(); i++) {
+            final Node n = texts.item(i);
+            for (Node child = n.getFirstChild(); child != null; child = child.getNextSibling()) {
+                if (child.getNodeType() == Node.TEXT_NODE) {
+                    assertFalse(child.getNodeValue().contains("\r"), child.getNodeValue());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void crlfBetweenElementsNormalizedToLf() throws Exception {
+        final Document doc = parse("<div>a\r\nb</div>");
+        final String text = first(doc, "//DIV").getFirstChild().getNodeValue();
+        assertFalse(text.contains("\r"), text);
+        assertTrue(text.contains("\n"), text);
+    }
+
+    @Test
+    public void bareLfLineEndingPreservedAsSingleLf() throws Exception {
+        final Document doc = parse("<p>x\ny</p>");
+        final String text = first(doc, "//P").getFirstChild().getNodeValue();
+        assertEquals("x\ny", text);
+    }
+
+    @Test
+    public void multipleSiblingsWithTextAndElementsPreserveExactOrder() throws Exception {
+        final Document doc = parse("<div>a<span>b</span>c<span>d</span>e</div>");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        assertEquals(List.of("text:a", "elem:SPAN", "text:c", "elem:SPAN", "text:e"), sig);
+    }
+
+    @Test
+    public void singleLevelListChildSignatureNoWhitespace() throws Exception {
+        final Document doc = parse("<ul><li>1</li><li>2</li></ul>");
+        final List<String> sig = childSignature(first(doc, "//UL"));
+        assertEquals(List.of("elem:LI", "elem:LI"), sig);
+    }
+
+    @Test
+    public void trailingNewlineAppearsEvenWhenRootHasAttributes() throws Exception {
+        final Document doc = parse("<div id=\"x\">y</div>");
+        final List<String> sig = childSignature(doc.getDocumentElement());
+        assertEquals("text:\n", sig.get(sig.size() - 1));
+    }
+
+    @Test
+    public void commentBeforeTrailingNewlineAtRoot() throws Exception {
+        final Document doc = parse("<p>x</p><!--c-->");
+        final List<String> sig = childSignature(doc.getDocumentElement());
+        assertEquals("text:\n", sig.get(sig.size() - 1));
+    }
+
+    @Test
+    public void emptyElementBetweenTextRunsSplitsIntoSeparateTextNodes() throws Exception {
+        final Document doc = parse("<p>before<br>after</p>");
+        final List<String> sig = childSignature(first(doc, "//P"));
+        assertEquals(List.of("text:before", "elem:BR", "text:after"), sig);
+    }
+
+    @Test
+    public void whitespaceOnlyTextNodeBetweenBlockElementsIsPreserved() throws Exception {
+        final Document doc = parse("<div><p>a</p> <p>b</p></div>");
+        final List<String> sig = childSignature(first(doc, "//DIV"));
+        assertEquals(List.of("elem:P", "text: ", "elem:P"), sig);
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidNumericCharRefTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidNumericCharRefTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.firstText;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests locking in end-to-end decimal and hexadecimal numeric character reference
+ * decoding through the full {@code DOMParser} parse path, on VALID/well-formed HTML input.
+ */
+public class ValidNumericCharRefTest {
+
+    @Test
+    public void decimalNumericReferencesDecodeToLetters() throws Exception {
+        final Document doc = parse("<p>&#65;&#66;&#67;</p>");
+        assertEquals("ABC", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexNumericReferenceWithLowerXDecodesToLetter() throws Exception {
+        final Document doc = parse("<p>&#x41;</p>");
+        assertEquals("A", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexNumericReferenceWithUpperXDecodesToLetter() throws Exception {
+        final Document doc = parse("<p>&#X41;</p>");
+        assertEquals("A", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexNumericReferenceIsCaseInsensitiveForDigitsLowerCase() throws Exception {
+        final Document doc = parse("<p>&#xd6;</p>");
+        assertEquals("Ö", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexNumericReferenceIsCaseInsensitiveForDigitsUpperCase() throws Exception {
+        final Document doc = parse("<p>&#xD6;</p>");
+        assertEquals("Ö", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void decimalEquivalentOfHexReferenceDecodesToSameChar() throws Exception {
+        final Document doc = parse("<p>&#214;</p>");
+        assertEquals("Ö", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void decimalReferenceForAmpersandDecodesToAmpersand() throws Exception {
+        final Document doc = parse("<p>&#38;</p>");
+        assertEquals("&", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void decimalReferenceForCopyrightSignDecodes() throws Exception {
+        final Document doc = parse("<p>&#169;</p>");
+        assertEquals("©", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void decimalSupplementaryPlaneReferenceDecodesToSurrogatePair() throws Exception {
+        final Document doc = parse("<p>&#128512;</p>");
+        final String text = firstText(doc, "//P");
+        assertEquals(2, text.length());
+        assertEquals(0x1F600, text.codePointAt(0));
+    }
+
+    @Test
+    public void hexSupplementaryPlaneReferenceDecodesToSurrogatePair() throws Exception {
+        final Document doc = parse("<p>&#x1F600;</p>");
+        final String text = firstText(doc, "//P");
+        assertEquals(2, text.length());
+        assertEquals(0x1F600, text.codePointAt(0));
+    }
+
+    @Test
+    public void semicolonOptionalForDecimalReferenceFollowedBySpace() throws Exception {
+        // characterization: the trailing ';' is optional for numeric references; a following space
+        // terminates the digit run and is preserved as-is.
+        final Document doc = parse("<p>&#65 X</p>");
+        assertEquals("A X", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void nullCodePointReferenceBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#0;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void surrogateCodePointReferenceBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#xD800;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void outOfUnicodeRangeReferenceBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#x110000;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void tabReferenceIsPreserved() throws Exception {
+        final Document doc = parse("<p>a&#9;b</p>");
+        // characterization: tab (0x9) is one of the XML-legal control-character exceptions and
+        // survives numeric-reference decoding unchanged.
+        assertEquals("a\tb", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void newlineReferenceIsPreserved() throws Exception {
+        final Document doc = parse("<p>a&#10;b</p>");
+        // characterization: line-feed (0xA) survives decoding as a literal '\n' character.
+        assertEquals("a\nb", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void carriageReturnReferenceIsPreserved() throws Exception {
+        final Document doc = parse("<p>a&#13;b</p>");
+        // characterization: carriage-return (0xD) survives decoding as a literal '\r' character; it is
+        // not normalized to '\n' since normalization only applies to raw line endings in the source,
+        // not to characters produced by entity decoding.
+        assertEquals("a\rb", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void combinedTabNewlineCarriageReturnReferencesAreAllPreserved() throws Exception {
+        final Document doc = parse("<p>&#9;&#10;&#13;</p>");
+        assertEquals("\t\n\r", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexLowerCaseDigitsDecodeHeavyBlackHeart() throws Exception {
+        final Document doc = parse("<p>&#x2764;</p>");
+        assertEquals("❤", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void hexUpperCaseDigitsDecodeHeavyBlackHeart() throws Exception {
+        final Document doc = parse("<p>&#X2764;</p>");
+        assertEquals("❤", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void controlCharacterOutsideTabLfCrBecomesReplacementChar() throws Exception {
+        // characterization: XML-illegal control characters other than tab/LF/CR become U+FFFD.
+        final Document doc = parse("<p>&#1;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void noncharacterFffeCodePointBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#xFFFE;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void noncharacterFfffCodePointBecomesReplacementChar() throws Exception {
+        final Document doc = parse("<p>&#xFFFF;</p>");
+        assertEquals("�", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void multipleDecimalReferencesInSequenceAllDecode() throws Exception {
+        final Document doc = parse("<p>&#72;&#101;&#108;&#108;&#111;</p>");
+        assertEquals("Hello", firstText(doc, "//P"));
+    }
+
+    @Test
+    public void mixedDecimalAndHexReferencesBothDecodeInSameText() throws Exception {
+        final Document doc = parse("<p>&#65;&#x42;&#67;</p>");
+        assertEquals("ABC", firstText(doc, "//P"));
+    }
+}

--- a/src/test/java/org/codelibs/nekohtml/parsers/ValidProcessingInstructionTest.java
+++ b/src/test/java/org/codelibs/nekohtml/parsers/ValidProcessingInstructionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.nekohtml.parsers;
+
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.count;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.parse;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.saxEvents;
+import static org.codelibs.nekohtml.parsers.BrokenHtmlTestSupport.saxStartElements;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.childSignature;
+import static org.codelibs.nekohtml.parsers.ValidHtmlTestSupport.lexicalEvents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Characterization tests for processing instructions and the XML declaration on VALID/well-formed
+ * HTML. The current {@code SimpleHTMLScanner} never recognizes {@code <?...?>} constructs: nothing
+ * ever calls {@code ContentHandler.processingInstruction}. Instead, the leading {@code '<'} is
+ * silently dropped (treated as an unrecognized tag) and the remainder of the construct leaks into
+ * the surrounding text as ordinary characters.
+ */
+public class ValidProcessingInstructionTest {
+
+    @Test
+    public void xmlDeclarationEmitsNoPiEvent() throws Exception {
+        final List<String> events = lexicalEvents("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        assertTrue(events.stream().noneMatch(e -> e.startsWith("pi:")), events.toString());
+    }
+
+    @Test
+    public void xmlDeclarationLeaksAsCharactersContainingDeclarationText() throws Exception {
+        final List<String> events = lexicalEvents("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        assertTrue(events.stream().anyMatch(e -> e.startsWith("chars:") && e.contains("xml version")), events.toString());
+    }
+
+    @Test
+    public void xmlDeclarationLeakedTextDropsOnlyLeadingAngleBracket() throws Exception {
+        // characterization: only the leading '<' is dropped; the rest, including the closing "?>",
+        // survives verbatim in the leaked characters
+        final List<String> events = lexicalEvents("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        assertTrue(events.contains("chars:?xml version=\"1.0\" encoding=\"UTF-8\"?>"), events.toString());
+    }
+
+    @Test
+    public void xmlDeclarationStillAllowsFollowingElementToParse() throws Exception {
+        final List<String> events = lexicalEvents("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        assertTrue(events.contains("start:P"), events.toString());
+        assertTrue(events.contains("chars:x"), events.toString());
+        assertTrue(events.contains("end:P"), events.toString());
+    }
+
+    @Test
+    public void domXmlDeclarationDoesNotPreventPElementParsing() throws Exception {
+        final Document doc = parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        assertEquals(1, count(doc, "//P"));
+    }
+
+    @Test
+    public void domXmlDeclarationLeaksAsStrayTextNodeAtRoot() throws Exception {
+        final Document doc = parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><p>x</p>");
+        final List<String> sig = childSignature(doc.getDocumentElement());
+        assertTrue(sig.stream().anyMatch(s -> s.startsWith("text:") && s.contains("xml version")), sig.toString());
+    }
+
+    @Test
+    public void phpProcessingInstructionEmitsNoPiEvent() throws Exception {
+        final List<String> events = lexicalEvents("<?php echo 1; ?><p>x</p>");
+        assertTrue(events.stream().noneMatch(e -> e.startsWith("pi:")), events.toString());
+    }
+
+    @Test
+    public void phpProcessingInstructionLeaksAsCharactersText() throws Exception {
+        final List<String> events = lexicalEvents("<?php echo 1; ?><p>x</p>");
+        assertTrue(events.contains("chars:?php echo 1; ?>"), events.toString());
+        assertTrue(events.contains("start:P"), events.toString());
+    }
+
+    @Test
+    public void phpProcessingInstructionSaxStartElementsShowOnlyRealElements() throws Exception {
+        // characterization: no pseudo-element is ever started for the "<?php ...?>" construct
+        final List<String> names = saxStartElements("<?php echo 1; ?><p>x</p>");
+        assertEquals(List.of("HTML", "P"), names);
+    }
+
+    @Test
+    public void piInMiddleOfDivLeaksIntoTextMergedWithFollowingContent() throws Exception {
+        // characterization: '<' is dropped, "?target data?>" leaks as text, and it merges with the
+        // following "after" text into a single characters run (no tag boundary between them)
+        final List<String> events = lexicalEvents("<div><?target data?>after</div>");
+        assertTrue(events.contains("chars:?target data?>after"), events.toString());
+    }
+
+    @Test
+    public void piInMiddleOfDivDomChildSignatureLocksExactText() throws Exception {
+        final Document doc = parse("<div><?target data?>after</div>");
+        final List<String> sig = childSignature(doc.getElementsByTagName("DIV").item(0));
+        assertEquals(List.of("text:?target data?>after"), sig);
+    }
+
+    @Test
+    public void piInMiddleDoesNotEmitStartElementForTargetPseudoTag() throws Exception {
+        final List<String> events = lexicalEvents("<div><?target data?>after</div>");
+        assertTrue(events.stream().noneMatch(e -> e.equals("start:target") || e.equals("start:?target")), events.toString());
+    }
+
+    @Test
+    public void saxEventsForXmlDeclarationContainNoQuestionMarkStartTag() throws Exception {
+        final List<String> events = saxEvents("<?xml version=\"1.0\"?><p>x</p>");
+        assertTrue(events.stream().noneMatch(e -> e.startsWith("start:?")), events.toString());
+    }
+
+    @Test
+    public void multiplePiLikeConstructsInSequenceEachLeakAsSeparateTextRuns() throws Exception {
+        // characterization: each "<?...?>" construct starts with its own dropped '<', which resets
+        // the text-scanning boundary; two adjacent PI-like constructs therefore leak as TWO separate
+        // "chars:" events rather than merging into one, unlike a single PI followed by plain text
+        final List<String> events = lexicalEvents("<?a?><?b?><p>x</p>");
+        assertTrue(events.contains("chars:?a?>"), events.toString());
+        assertTrue(events.contains("chars:?b?>"), events.toString());
+        assertTrue(events.indexOf("chars:?a?>") < events.indexOf("chars:?b?>"), events.toString());
+        assertTrue(events.indexOf("chars:?b?>") < events.indexOf("start:P"), events.toString());
+    }
+
+    @Test
+    public void piConstructDoesNotAffectVoidElementHandlingAfterward() throws Exception {
+        final Document doc = parse("<?xml version=\"1.0\"?><img src=\"a.png\">");
+        assertEquals(1, count(doc, "//IMG"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive **characterization / regression test suite** for NekoHTML,
covering both **broken/malformed** and **valid/well-formed** HTML. NekoHTML is a
lenient parser; this PR locks in the parser's **current** behavior so future
refactors surface any unintended change (degradation).

**No implementation code was changed** — these are pure characterization tests
based on the current output. Some locked behaviors are intentionally non-standard
(differ from browsers/HTML5) and are marked as such in the tests.

## Approach

- Follows the existing test idiom: `DOMParser` + XPath and `SAXParser` + event
  collection. Element names are uppercase, attribute names lowercase.
- Two small test-only helpers using only public parser APIs:
  - `BrokenHtmlTestSupport` (`parse` / `count` / `nodes` / `first` / `firstText`
    / `saxStartElements` / `saxEvents`).
  - `ValidHtmlTestSupport` (`parseBytes` / `lexicalEvents` / `saxQNameUriLocal`
    / `saxEventsWithFeature` / `childSignature`) for lexical-event capture,
    byte-stream decoding, feature toggling and DOM child-signature assertions.
- Assertions favor concrete structural checks (element counts, parent/child,
  sibling order, attributes, exact decoded characters, exact event streams) so
  regressions in behavior are actually caught.

## Coverage — broken tag structures (15 categories)

| Category | Focus |
|---|---|
| Unclosed tags | EOF LIFO auto-close, nested unclosed |
| Misnested / mismatched | Adoption Agency Algorithm final DOM shape |
| Stray / orphan end tags | DOM drops them; SAX still emits the end event |
| No sibling auto-close | `<p>a<p>b` nests; consecutive `<li>`/`<dt>`/`<tr>` nest |
| Void & self-closing | 13 void elements; non-void `<div/>` slash ignored |
| Table structures | no implicit `<tbody>`, no table-context forcing |
| List structures | no `<li>` parent completion; nested lists kept |
| Attribute syntax | unquoted split, quoted `>` ends tag, duplicate = last wins |
| Comments / DOCTYPE / CDATA / PI | unclosed comment leaks as text; DOCTYPE not in DOM |
| Raw-text elements | script/style/textarea have no raw-text mode |
| Entities | unknown left verbatim, optional `;`, invalid → U+FFFD |
| Malformed tag names/syntax | bare `<` dropped, `<my-tag>`, `<ns:tag>` |
| Implicit structure | only HTML root auto-created (no HEAD/BODY) |
| Chaotic combos | empty/degenerate input, deep nesting, combined breakage |
| Config modes | `nekohtml.dom.strict`, `balance-tags`, lexical handler |

## Coverage — valid / happy-path input (new)

Targets the thin/absent happy-path areas found by auditing the existing suite
(tables, forms, void elements, HTML5 semantics, etc. were already well covered).

| Category | Focus |
|---|---|
| Entity decoding (end-to-end) | named/numeric decode to EXACT chars in text and attribute values, HTML5 attribute no-decode rule |
| Numeric char references | decimal/hex (case-insensitive), supplementary-plane surrogate pairs, invalid → U+FFFD |
| DOCTYPE | `getDoctype()==null`; SAX `startDTD("html", null, null)` regardless of the actual doctype |
| Comments / CDATA | LexicalHandler events; CDATA verbatim, exposed as a Text node (not CDATASection) |
| Processing instructions | not recognized — `<` dropped, remainder leaks as text (locked as-is) |
| DOM node contract | node types, `getOwnerDocument`, `NamedNodeMap`, `getElementsByTagName` order |
| Child-node ordering | exact text/element interleaving, whitespace preserved, trailing `\n` node |
| Encoding & BOM | byte-stream decode by InputSource encoding, meta charset NOT auto-detected, BOM not stripped |
| Namespace / prefixed names | `uri=""`, prefixes kept & uppercased (`o:p` → `O:P`), no namespace resolution |
| Config no-op guards | `namespaces`/`augmentations`/`report-errors`/`html5-mode` are no-ops; only `balance-tags` changes output |

## Notable current behaviors locked (characterization)

- No sibling auto-close: consecutive block/list/table items **nest** rather than
  becoming siblings.
- Only the `HTML` root is implicitly created; `HEAD`/`BODY` are not auto-inserted.
- A trailing `/` on a non-void element (`<div/>`) is ignored, leaving it open.
- `<script>`/`<style>` content is entity-decoded and tag-like content is parsed
  as markup (no raw-text mode).
- The scanner appends `\n` per line (incl. EOF) and normalizes CR/CRLF to `\n`,
  so a trailing `\n` text node appears at the root.
- DOCTYPE is reduced to `startDTD("html", null, null)` and dropped from the DOM.
- Meta charset / BOM are not auto-detected; a UTF-8 BOM appears as a leading
  U+FEFF text node.
- Processing instructions / XML declarations are not recognized and leak as text.
- `namespaces`, `augmentations`, `report-errors`, `html5-mode` currently have no
  observable effect; only `balance-tags` changes output (regression-guarded).

## Testing

- Added ~500 new tests total (two helpers + 15 broken-HTML classes + 11
  valid-HTML classes).
- Full suite green: **1770 tests, 0 failures, 0 errors** (`mvn test`).
- `mvn formatter:format` and `mvn license:format` applied.
